### PR TITLE
Add native mobile home with bottom tab bar and docked search

### DIFF
--- a/@types/nextjs-routes.d.ts
+++ b/@types/nextjs-routes.d.ts
@@ -13,6 +13,7 @@ declare module "nextjs-routes" {
   export type Route =
     | StaticRoute<"/">
     | StaticRoute<"/api/build-id">
+    | StaticRoute<"/demo-mobil">
     | StaticRoute<"/kontakt">
     | StaticRoute<"/nahrat">
     | StaticRoute<"/nahrat/hledani">

--- a/content/chvalotce.d.json.ts
+++ b/content/chvalotce.d.json.ts
@@ -1004,6 +1004,14 @@ declare const messages: {
 		"merged": "Sloučeno",
 		"filterActive": "Aktivní & otevřené PR",
 		"noActiveOrOpenPr": "Žádné aktivní úlohy ani otevřené PR"
+	},
+	"demo": {
+		"songOfDay": "Píseň dne",
+		"moreIdeas": "Další nápady",
+		"assistantGreeting": "Ahoj! Jakou píseň dneska hledáš?",
+		"tryChips": "Zkus třeba",
+		"goodDay": "Dobrý den",
+		"browseAll": "Všechny písně"
 	}
 };
 export default messages;

--- a/content/chvalotce.json
+++ b/content/chvalotce.json
@@ -1001,5 +1001,13 @@
 		"merged": "Sloučeno",
 		"filterActive": "Aktivní & otevřené PR",
 		"noActiveOrOpenPr": "Žádné aktivní úlohy ani otevřené PR"
+	},
+	"demo": {
+		"songOfDay": "Píseň dne",
+		"moreIdeas": "Další nápady",
+		"assistantGreeting": "Ahoj! Jakou píseň dneska hledáš?",
+		"tryChips": "Zkus třeba",
+		"goodDay": "Dobrý den",
+		"browseAll": "Všechny písně"
 	}
 }

--- a/content/chwalmy.json
+++ b/content/chwalmy.json
@@ -1001,5 +1001,13 @@
 		"merged": "Połączone",
 		"filterActive": "Aktywne i otwarte PR",
 		"noActiveOrOpenPr": "Brak aktywnych zadań ani otwartych PR"
+	},
+	"demo": {
+		"songOfDay": "Pieśń dnia",
+		"moreIdeas": "Więcej propozycji",
+		"assistantGreeting": "Cześć! Jakiej pieśni dziś szukasz?",
+		"tryChips": "Spróbuj np.",
+		"goodDay": "Dzień dobry",
+		"browseAll": "Wszystkie pieśni"
 	}
 }

--- a/content/hallelujahhub.json
+++ b/content/hallelujahhub.json
@@ -1001,5 +1001,13 @@
 		"merged": "Merged",
 		"filterActive": "Active & open PRs",
 		"noActiveOrOpenPr": "No active tasks or open PRs"
+	},
+	"demo": {
+		"songOfDay": "Song of the day",
+		"moreIdeas": "More ideas",
+		"assistantGreeting": "Hi! What song are you looking for today?",
+		"tryChips": "Try one of these",
+		"goodDay": "Hello",
+		"browseAll": "All songs"
 	}
 }

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -24,10 +24,14 @@ import { getAssetUrl } from '@/tech/paths.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
 	AutoAwesomeRounded,
+	HomeOutlined,
 	HomeRounded,
+	LibraryMusicOutlined,
+	LibraryMusicRounded,
 	LoginRounded,
 	MusicNoteRounded,
 	PersonOutlineRounded,
+	PersonRounded,
 	QueueMusicRounded,
 	ScheduleRounded,
 	SearchRounded,
@@ -172,21 +176,24 @@ function DemoMobilePage() {
 		</Box>
 	)
 
+	// circular icon button reads more native than an uppercase text link
 	const loginLink = (
-		<Clickable>
+		<Clickable tooltip={tNav('login')}>
 			<Link to="login" params={{ previousPage: '', message: '' }}>
 				<Box
+					aria-label={tNav('login')}
 					sx={{
+						width: 42,
+						height: 42,
+						borderRadius: 10,
+						bgcolor: blueSystem || googleMinimal ? 'grey.100' : 'background.paper',
+						boxShadow: blueSystem || googleMinimal ? 0 : 1,
+						color: 'primary.main',
 						display: 'flex',
 						alignItems: 'center',
-						gap: 0.5,
-						color: 'primary.main',
-						paddingY: 0.5,
+						justifyContent: 'center',
 					}}
 				>
-					<Typography small strong uppercase>
-						{tNav('login')}
-					</Typography>
 					<LoginRounded fontSize="small" />
 				</Box>
 			</Link>
@@ -249,8 +256,8 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// Shared section anatomy: panel with header (badge in v4 + title +
-	// optional action) and content — identical geometry in every variant
+	// Shared section anatomy: iOS-style grouped list — small uppercase
+	// label ABOVE the card (h6 + badge in the blue system), then the panel
 	const Section = ({
 		title,
 		icon,
@@ -262,7 +269,37 @@ function DemoMobilePage() {
 		action?: ReactNode
 		children: ReactNode
 	}) => (
-		<Box sx={{ paddingX: 2.5 }}>
+		<Box
+			sx={{
+				paddingX: 2.5,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 1,
+			}}
+		>
+			<Box
+				sx={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					gap: 1,
+					paddingX: 0.5,
+				}}
+			>
+				<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+					{blueSystem && sectionBadge(icon)}
+					{blueSystem ? (
+						<Typography variant="h6" strong>
+							{title}
+						</Typography>
+					) : (
+						<Typography small strong uppercase color="grey.700">
+							{title.replace(/:$/, '')}
+						</Typography>
+					)}
+				</Box>
+				{action}
+			</Box>
 			<Box
 				sx={{
 					bgcolor: panelBg,
@@ -274,22 +311,6 @@ function DemoMobilePage() {
 					gap: 2,
 				}}
 			>
-				<Box
-					sx={{
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'space-between',
-						gap: 1,
-					}}
-				>
-					<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
-						{blueSystem && sectionBadge(icon)}
-						<Typography variant="h6" strong>
-							{title}
-						</Typography>
-					</Box>
-					{action}
-				</Box>
 				{children}
 			</Box>
 		</Box>
@@ -686,7 +707,9 @@ function DemoMobilePage() {
 						transform: 'translateX(-50%)',
 						width: '100%',
 						maxWidth: PAGE_MAX_WIDTH,
-						bgcolor: 'background.paper',
+						// translucent + blur like native bars
+						bgcolor: alpha(theme.palette.background.paper, 0.85),
+						backdropFilter: 'blur(12px)',
 						borderTop: '1px solid',
 						borderColor: 'grey.300',
 						display: 'flex',
@@ -696,7 +719,8 @@ function DemoMobilePage() {
 				>
 					<Link to="demoMobile" params={{ v }} style={{ flex: 1 }}>
 						<TabItem
-							icon={<HomeRounded />}
+							icon={<HomeOutlined />}
+							activeIcon={<HomeRounded />}
 							label={tNav('home')}
 							active
 							pill={blueSystem}
@@ -704,7 +728,8 @@ function DemoMobilePage() {
 					</Link>
 					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
 						<TabItem
-							icon={<QueueMusicRounded />}
+							icon={<LibraryMusicOutlined />}
+							activeIcon={<LibraryMusicRounded />}
 							label={tNav('songs')}
 							pill={blueSystem}
 						/>
@@ -712,6 +737,7 @@ function DemoMobilePage() {
 					<Link to="account" params={{}} style={{ flex: 1 }}>
 						<TabItem
 							icon={<PersonOutlineRounded />}
+							activeIcon={<PersonRounded />}
 							label={tNav('account')}
 							pill={blueSystem}
 						/>
@@ -724,13 +750,15 @@ function DemoMobilePage() {
 
 type TabItemProps = {
 	icon: JSX.Element
+	/** filled counterpart shown when the tab is selected (native pattern) */
+	activeIcon?: JSX.Element
 	label: string
 	active?: boolean
 	/** Material-3-like tonal pill behind the active icon */
 	pill?: boolean
 }
 
-function TabItem({ icon, label, active, pill }: TabItemProps) {
+function TabItem({ icon, activeIcon, label, active, pill }: TabItemProps) {
 	const theme = useTheme()
 	return (
 		<Box
@@ -757,7 +785,7 @@ function TabItem({ icon, label, active, pill }: TabItemProps) {
 					}),
 				}}
 			>
-				{icon}
+				{active ? activeIcon ?? icon : icon}
 			</Box>
 			<Typography small strong={active ? 700 : 400}>
 				{label}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -71,8 +71,9 @@ function DemoMobilePage() {
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
+	// connected square search bar (3) is the picked default
 	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 1
+		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 3
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -79,8 +79,9 @@ function DemoMobilePage() {
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
+	// docked search (2) won the design review — it is the default
 	const variant: DemoVariant =
-		parsed >= 2 && parsed <= 5 ? (parsed as DemoVariant) : 1
+		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 2
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -3,23 +3,19 @@
 import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
-import {
-	Box,
-	Clickable,
-	Divider,
-	Typography,
-	useTheme,
-} from '@/common/ui'
-import { Link } from '@/common/ui/Link/Link'
+import { Box, Clickable, Divider, Image, Typography, useTheme } from '@/common/ui'
 import { alpha } from '@/common/ui/mui'
+import { Link } from '@/common/ui/Link/Link'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
-import { SongVariantCard } from '@/common/ui/SongCard'
 import { TextField } from '@/common/ui/TextField'
 import { useSmartNavigate } from '@/routes/useSmartNavigate'
 import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
+import { getAssetUrl } from '@/tech/paths.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
+	ArrowForwardRounded,
+	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
 	LibraryMusicOutlined,
@@ -30,8 +26,9 @@ import {
 	PersonRounded,
 	SearchRounded,
 } from '@mui/icons-material'
+import { Sheet } from '@pepavlin/sheet-api'
 import { useTranslations } from 'next-intl'
-import { Fragment, ReactNode, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { BasicVariantPack } from '../../../api/dtos'
 
 export default SmartPage(DemoMobilePage, [
@@ -44,26 +41,27 @@ export default SmartPage(DemoMobilePage, [
 
 const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
-const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
+const TAB_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
+const DOCKED_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
-type DemoVariant = 1 | 2 | 3 | 4
-type HeaderStyle = 'white' | 'lightgrey' | 'dark' | 'elevated'
+type DemoVariant = 1 | 2 | 3 | 4 | 5
 
 /**
- * One base design (square header, alternating full-bleed band sections,
- * docked gradient search, translucent tab bar). The header color is the
- * experiment — no brand blue up top, it stays in the search and accents:
+ * Five structurally different landing concepts (not recolors), all inside
+ * the same native shell (bottom tab bar):
  *
- * 1 — white: flat white header, dark text
- * 2 — lightgrey: grey.100 header, band order flipped so surfaces alternate
- * 3 — dark: grey.900 header with white text
- * 4 — elevated: white header lifted with a soft shadow (classic app bar)
+ * 1 — shelves: Spotify-style greeting + horizontal shelves of square art
+ * 2 — grid: colorful mood-tile grid (big rounded cards)
+ * 3 — editorial: a "song of the day" hero + compact idea list
+ * 4 — chat: conversational assistant with suggestion chips + compose bar
+ * 5 — index: utilitarian sticky-search list, dense and fast
  */
 function DemoMobilePage() {
 	const theme = useTheme()
 	const tHome = useTranslations('home')
 	const tNav = useTranslations('navigation')
 	const tSearch = useTranslations('search')
+	const tDemo = useTranslations('demo')
 
 	const navigate = useSmartNavigate()
 	const [query, setQuery] = useState('')
@@ -71,40 +69,62 @@ function DemoMobilePage() {
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
 	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 1
+		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 1
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
 
-	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
+	const p = theme.palette
+	const gradient = `linear-gradient(135deg, ${p.primary.main}, ${p.primary.dark})`
 
-	const headerStyle: HeaderStyle = (
-		['white', 'lightgrey', 'dark', 'elevated'] as const
-	)[variant - 1]
-	const darkHeader = headerStyle === 'dark'
-
-	// lightgrey header flips the band order so adjacent surfaces alternate
-	const recommendedSurface: 'white' | 'grey' =
-		headerStyle === 'lightgrey' ? 'white' : 'grey'
-	const lastAddedSurface: 'white' | 'grey' =
-		headerStyle === 'lightgrey' ? 'grey' : 'white'
+	// deterministic "cover art" gradients derived from palette tokens
+	const artGradients = [
+		`linear-gradient(135deg, ${p.primary.main}, ${p.primary.dark})`,
+		`linear-gradient(135deg, ${p.info.main}, ${p.primary.main})`,
+		`linear-gradient(135deg, ${p.success.main}, ${p.info.main})`,
+		`linear-gradient(135deg, ${p.secondary.main}, ${p.warning.main})`,
+		`linear-gradient(135deg, ${p.primary.dark}, ${p.error.main})`,
+	]
+	const artFor = (i: number) => artGradients[i % artGradients.length]
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
-		if (query.trim().length > 0) {
-			navigate('home', { hledat: query.trim() })
+		if (query.trim().length > 0) navigate('home', { hledat: query.trim() })
+	}
+
+	const firstLine = (sheetData: string) => {
+		try {
+			return (
+				new Sheet(sheetData)
+					.getSections()[0]
+					?.text?.split('\n')
+					.find((l) => l.trim().length > 0) ?? ''
+			)
+		} catch {
+			return ''
 		}
 	}
 
-	// gradient border + shadow keep the search the strongest element
-	const searchForm = (
+	const rec = recommended.data
+	const last = lastAdded.data
+	const loading = recommended.isLoading || lastAdded.isLoading
+
+	// ---- shared bits -------------------------------------------------
+
+	const searchField = (
+		<>
+			<SearchRounded sx={{ color: 'grey.600' }} />
+			<TextField
+				value={query}
+				onChange={setQuery}
+				placeholder={tSearch('searchByTitleOrText')}
+			/>
+		</>
+	)
+
+	const searchPill = (
 		<Box
-			sx={{
-				background: gradient,
-				padding: '2px',
-				borderRadius: 10,
-				boxShadow: 3,
-			}}
+			sx={{ background: gradient, padding: '2px', borderRadius: 10, boxShadow: 3 }}
 		>
 			<Box
 				component="form"
@@ -119,18 +139,12 @@ function DemoMobilePage() {
 					paddingY: 1.5,
 				}}
 			>
-				<SearchRounded sx={{ color: 'grey.600' }} />
-				<TextField
-					value={query}
-					onChange={setQuery}
-					placeholder={tSearch('searchByTitleOrText')}
-				/>
+				{searchField}
 			</Box>
 		</Box>
 	)
 
-	// circular icon button reads more native than an uppercase text link
-	const loginButton = (
+	const loginCircle = (
 		<Clickable tooltip={tNav('login')}>
 			<Link to="login" params={{ previousPage: '', message: '' }}>
 				<Box
@@ -139,12 +153,8 @@ function DemoMobilePage() {
 						width: 42,
 						height: 42,
 						borderRadius: 10,
-						bgcolor: darkHeader
-							? alpha(theme.palette.common.white, 0.16)
-							: headerStyle === 'lightgrey'
-							? 'background.paper'
-							: 'grey.100',
-						color: darkHeader ? 'common.white' : 'primary.main',
+						bgcolor: 'grey.100',
+						color: 'primary.main',
 						display: 'flex',
 						alignItems: 'center',
 						justifyContent: 'center',
@@ -156,7 +166,18 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const sectionLabel = (title: string, action?: ReactNode) => (
+	const greeting = (
+		<Box>
+			<Typography small color="grey.700">
+				{tHome('hero.lead')}
+			</Typography>
+			<Typography variant="h3" strong={800}>
+				{tHome('hero.title')}
+			</Typography>
+		</Box>
+	)
+
+	const label = (text: string, action?: ReactNode) => (
 		<Box
 			sx={{
 				display: 'flex',
@@ -167,7 +188,7 @@ function DemoMobilePage() {
 			}}
 		>
 			<Typography small strong uppercase color="grey.700">
-				{title.replace(/:$/, '')}
+				{text.replace(/:$/, '')}
 			</Typography>
 			{action}
 		</Box>
@@ -183,137 +204,461 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	// full-bleed band section
-	const Section = ({
-		title,
-		action,
-		surface,
-		children,
-	}: {
-		title: string
-		action?: ReactNode
-		surface: 'white' | 'grey'
-		children: ReactNode
-	}) => (
-		<Box
-			sx={{
-				bgcolor: surface === 'grey' ? 'grey.100' : 'background.paper',
-				paddingY: 2.5,
-				paddingX: 2.5,
-				display: 'flex',
-				flexDirection: 'column',
-				gap: 1.5,
-			}}
-		>
-			{sectionLabel(title, action)}
-			{children}
-		</Box>
-	)
+	// ---- variant 1: Spotify-style shelves ----------------------------
 
-	const carouselTile = (s: BasicVariantPack, bg: string) => (
+	const shelfTile = (s: BasicVariantPack, i: number) => (
 		<Clickable key={s.packGuid}>
 			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-				<Box
-					sx={{
-						width: 164,
-						bgcolor: bg,
-						borderRadius: 2,
-						padding: 2,
-						scrollSnapAlign: 'start',
-						display: 'flex',
-						flexDirection: 'column',
-						gap: 0.75,
-					}}
-				>
+				<Box sx={{ width: 132, display: 'flex', flexDirection: 'column', gap: 1 }}>
 					<Box
 						sx={{
-							width: 36,
-							height: 36,
-							borderRadius: 1.5,
-							bgcolor: alpha(theme.palette.primary.main, 0.1),
-							color: 'primary.main',
+							width: 132,
+							height: 132,
+							borderRadius: 3,
+							background: artFor(i),
+							color: 'common.white',
 							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-							marginBottom: 0.75,
+							alignItems: 'flex-end',
+							padding: 1.25,
+							boxShadow: 1,
 						}}
 					>
-						<MusicNoteRounded fontSize="small" />
+						<MusicNoteRounded />
 					</Box>
-					<Typography strong noWrap>
+					<Typography strong noWrap sx={{ paddingX: 0.5 }}>
 						{s.title}
 					</Typography>
-					{s.publishedAt && (
-						<Typography small color="grey.700">
-							{getSmartDateAgoString(s.publishedAt)}
-						</Typography>
-					)}
 				</Box>
 			</Link>
 		</Clickable>
 	)
 
-	const listSkeletons = Array.from({ length: 5 }).map((_, i) => (
-		<Skeleton
-			key={i}
-			variant="rounded"
-			sx={{ height: 60, borderRadius: 2, bgcolor: 'grey.200' }}
-		/>
-	))
-
-	const carouselSkeletons = Array.from({ length: 3 }).map((_, i) => (
-		<Skeleton
-			key={i}
-			variant="rounded"
-			sx={{ minWidth: 164, height: 128, borderRadius: 2, bgcolor: 'grey.200' }}
-		/>
-	))
-
-	// carousel bleeds to the section edge; the inset matches its padding
-	const carouselBleed = 2.5
-
-	const recommendedRows = (
-		<Box sx={{ display: 'flex', flexDirection: 'column' }}>
-			{recommended.isLoading
-				? listSkeletons
-				: recommended.data.slice(0, 5).map((s, i, arr) => (
-						<Fragment key={s.packGuid}>
-							<SongVariantCard
-								data={s}
-								dense
-								sx={{ bgcolor: 'transparent', borderRadius: 0 }}
+	const shelf = (title: string, songs: BasicVariantPack[], offset = 0) => (
+		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+			<Box sx={{ paddingX: 2.5 }}>{label(title, browseAction)}</Box>
+			<Box
+				sx={{
+					display: 'flex',
+					gap: 1.5,
+					overflowX: 'auto',
+					paddingX: 2.5,
+					paddingBottom: 0.5,
+					scrollSnapType: 'x mandatory',
+					'&::-webkit-scrollbar': { display: 'none' },
+				}}
+			>
+				{loading
+					? Array.from({ length: 4 }).map((_, i) => (
+							<Skeleton
+								key={i}
+								variant="rounded"
+								sx={{ minWidth: 132, height: 164, borderRadius: 3, bgcolor: 'grey.200' }}
 							/>
-							{i < arr.length - 1 && <Divider sx={{ marginX: 1 }} />}
-						</Fragment>
-				  ))}
+					  ))
+					: songs.slice(0, 8).map((s, i) => shelfTile(s, i + offset))}
+			</Box>
 		</Box>
 	)
 
-	const lastAddedCarousel = (tilesBg: string) => (
+	const shelvesVariant = (
+		<>
+			<Box sx={{ paddingX: 2.5, paddingTop: 3, paddingBottom: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+				<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
+					{greeting}
+					{loginCircle}
+				</Box>
+				{searchPill}
+			</Box>
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingBottom: TAB_CLEARANCE }}>
+				{shelf(tHome('recommended.idea'), rec)}
+				{shelf(tHome('lastAdded.title'), last, 2)}
+			</Box>
+		</>
+	)
+
+	// ---- variant 2: colorful mood grid -------------------------------
+
+	const gridTile = (s: BasicVariantPack, i: number) => (
+		<Clickable key={s.packGuid}>
+			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+				<Box
+					sx={{
+						height: 150,
+						borderRadius: 3,
+						background: artFor(i),
+						color: 'common.white',
+						padding: 1.75,
+						display: 'flex',
+						flexDirection: 'column',
+						justifyContent: 'space-between',
+						boxShadow: 1,
+					}}
+				>
+					<Box
+						sx={{
+							width: 34,
+							height: 34,
+							borderRadius: 2,
+							bgcolor: alpha(theme.palette.common.white, 0.25),
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+						}}
+					>
+						<MusicNoteRounded fontSize="small" />
+					</Box>
+					<Typography strong>{s.title}</Typography>
+				</Box>
+			</Link>
+		</Clickable>
+	)
+
+	const gridVariant = (
+		<>
+			<Box sx={{ paddingX: 2.5, paddingTop: 3, paddingBottom: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+				<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
+					{greeting}
+					{loginCircle}
+				</Box>
+				{searchPill}
+			</Box>
+			<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5, paddingBottom: TAB_CLEARANCE }}>
+				{label(tHome('recommended.idea'))}
+				<Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5 }}>
+					{loading
+						? Array.from({ length: 6 }).map((_, i) => (
+								<Skeleton key={i} variant="rounded" sx={{ height: 150, borderRadius: 3, bgcolor: 'grey.200' }} />
+						  ))
+						: rec.slice(0, 6).map((s, i) => gridTile(s, i))}
+				</Box>
+			</Box>
+		</>
+	)
+
+	// ---- variant 3: editorial "song of the day" ----------------------
+
+	const feature = rec[0]
+	const editorialVariant = (
+		<>
+			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
+				{greeting}
+				{loginCircle}
+			</Box>
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: DOCKED_CLEARANCE }}>
+				<Box sx={{ paddingX: 2.5 }}>
+					{loading || !feature ? (
+						<Skeleton variant="rounded" sx={{ height: 220, borderRadius: 4, bgcolor: 'grey.200' }} />
+					) : (
+						<Clickable>
+							<Link to="variant" params={parseVariantAlias(feature.packAlias)}>
+								<Box
+									sx={{
+										height: 220,
+										borderRadius: 4,
+										background: gradient,
+										color: 'common.white',
+										padding: 3,
+										display: 'flex',
+										flexDirection: 'column',
+										justifyContent: 'space-between',
+										boxShadow: 3,
+									}}
+								>
+									<Typography small strong uppercase sx={{ opacity: 0.85 }}>
+										{tDemo('songOfDay')}
+									</Typography>
+									<Box>
+										<Typography variant="h4" strong={800}>
+											{feature.title}
+										</Typography>
+										<Typography sx={{ opacity: 0.9 }} noWrap>
+											{firstLine(feature.sheetData)}
+										</Typography>
+									</Box>
+								</Box>
+							</Link>
+						</Clickable>
+					)}
+				</Box>
+
+				<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+					{label(tDemo('moreIdeas'), browseAction)}
+					<Box sx={{ display: 'flex', flexDirection: 'column' }}>
+						{loading
+							? Array.from({ length: 4 }).map((_, i) => (
+									<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
+							  ))
+							: rec.slice(1, 6).map((s, i, arr) => (
+									<Box key={s.packGuid}>
+										<Clickable>
+											<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+												<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25 }}>
+													<Box
+														sx={{
+															width: 44,
+															height: 44,
+															borderRadius: 2,
+															background: artFor(i + 1),
+															color: 'common.white',
+															display: 'flex',
+															alignItems: 'center',
+															justifyContent: 'center',
+															flexShrink: 0,
+														}}
+													>
+														<MusicNoteRounded fontSize="small" />
+													</Box>
+													<Box sx={{ minWidth: 0, flex: 1 }}>
+														<Typography strong noWrap>
+															{s.title}
+														</Typography>
+														<Typography small color="grey.700" noWrap>
+															{firstLine(s.sheetData)}
+														</Typography>
+													</Box>
+													<ChevronRightRounded sx={{ color: 'grey.500' }} />
+												</Box>
+											</Link>
+										</Clickable>
+										{i < arr.length - 1 && <Divider />}
+									</Box>
+							  ))}
+					</Box>
+				</Box>
+			</Box>
+			<DockedSearch>{searchPill}</DockedSearch>
+		</>
+	)
+
+	// ---- variant 4: chat assistant -----------------------------------
+
+	const chatChip = (s: BasicVariantPack) => (
+		<Clickable key={s.packGuid}>
+			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+				<Box
+					sx={{
+						bgcolor: 'background.paper',
+						border: '1px solid',
+						borderColor: 'grey.300',
+						borderRadius: 10,
+						paddingX: 2,
+						paddingY: 1,
+					}}
+				>
+					<Typography small strong noWrap>
+						{s.title}
+					</Typography>
+				</Box>
+			</Link>
+		</Clickable>
+	)
+
+	const bubble = (children: ReactNode) => (
 		<Box
 			sx={{
-				display: 'flex',
-				gap: 1.5,
-				overflowX: 'auto',
-				marginX: -carouselBleed,
-				paddingLeft: carouselBleed,
-				paddingY: 0.5,
-				scrollSnapType: 'x mandatory',
-				scrollPaddingLeft: theme.spacing(carouselBleed),
-				'&::-webkit-scrollbar': { display: 'none' },
-				// keeps the right inset visible at the end of the scroll
-				// (trailing padding collapses in overflow containers)
-				'&::after': {
-					content: '""',
-					flex: '0 0 1px',
-				},
+				alignSelf: 'flex-start',
+				maxWidth: '85%',
+				bgcolor: 'grey.100',
+				borderRadius: '4px 18px 18px 18px',
+				paddingX: 2,
+				paddingY: 1.25,
 			}}
 		>
-			{lastAdded.isLoading
-				? carouselSkeletons
-				: lastAdded.data.slice(0, 8).map((s) => carouselTile(s, tilesBg))}
+			{children}
 		</Box>
 	)
+
+	const chatVariant = (
+		<>
+			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
+				{greeting}
+				{loginCircle}
+			</Box>
+			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', flexDirection: 'column', gap: 2, paddingBottom: DOCKED_CLEARANCE }}>
+				<Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
+					<Box
+						sx={{
+							width: 36,
+							height: 36,
+							borderRadius: 10,
+							bgcolor: 'grey.100',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							flexShrink: 0,
+						}}
+					>
+						<Image src={getAssetUrl('/sheeps/ovce3.svg')} alt="" width={26} height={26} />
+					</Box>
+					{bubble(<Typography>{tDemo('assistantGreeting')}</Typography>)}
+				</Box>
+
+				{bubble(
+					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+						<Typography small color="grey.700">
+							{tDemo('tryChips')}
+						</Typography>
+						<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+							{loading
+								? Array.from({ length: 4 }).map((_, i) => (
+										<Skeleton key={i} variant="rounded" sx={{ width: 120, height: 34, borderRadius: 10, bgcolor: 'grey.200' }} />
+								  ))
+								: rec.slice(0, 5).map((s) => chatChip(s))}
+						</Box>
+					</Box>
+				)}
+
+				{bubble(
+					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+						<Typography small color="grey.700">
+							{tHome('lastAdded.title')}
+						</Typography>
+						<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+							{!loading && last.slice(0, 4).map((s) => chatChip(s))}
+						</Box>
+					</Box>
+				)}
+			</Box>
+
+			<DockedSearch>
+				<Box
+					component="form"
+					onSubmit={submitSearch}
+					sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+				>
+					<Box
+						sx={{
+							flex: 1,
+							display: 'flex',
+							alignItems: 'center',
+							gap: 1,
+							bgcolor: 'background.paper',
+							border: '1px solid',
+							borderColor: 'grey.300',
+							borderRadius: 10,
+							paddingX: 2,
+							paddingY: 1.5,
+							boxShadow: 2,
+						}}
+					>
+						{searchField}
+					</Box>
+					<Box
+						role="button"
+						aria-label={tSearch('searchByTitleOrText')}
+						onClick={() => query.trim() && navigate('home', { hledat: query.trim() })}
+						sx={{
+							width: 48,
+							height: 48,
+							borderRadius: 10,
+							background: gradient,
+							color: 'common.white',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							flexShrink: 0,
+							boxShadow: 3,
+						}}
+					>
+						<ArrowForwardRounded />
+					</Box>
+				</Box>
+			</DockedSearch>
+		</>
+	)
+
+	// ---- variant 5: utilitarian index --------------------------------
+
+	const indexList = (() => {
+		const seen = new Set<string>()
+		return [...rec, ...last].filter((s) => {
+			if (seen.has(s.packGuid)) return false
+			seen.add(s.packGuid)
+			return true
+		})
+	})()
+
+	const indexVariant = (
+		<>
+			<Box
+				sx={{
+					position: 'sticky',
+					top: 0,
+					zIndex: 5,
+					bgcolor: 'background.paper',
+					paddingX: 2.5,
+					paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
+					paddingBottom: 2,
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 2,
+					borderBottom: '1px solid',
+					borderColor: 'grey.200',
+				}}
+			>
+				<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
+					{greeting}
+					{loginCircle}
+				</Box>
+				<Box
+					component="form"
+					onSubmit={submitSearch}
+					sx={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 1,
+						bgcolor: 'grey.100',
+						borderRadius: 3,
+						paddingX: 2,
+						paddingY: 1.5,
+					}}
+				>
+					{searchField}
+				</Box>
+			</Box>
+
+			<Box sx={{ paddingTop: 1.5, paddingBottom: TAB_CLEARANCE }}>
+				<Box sx={{ paddingX: 2.5, paddingBottom: 0.5 }}>{label(tDemo('browseAll'))}</Box>
+				{loading
+					? Array.from({ length: 8 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ height: 44, borderRadius: 1, bgcolor: 'grey.200', mx: 2.5, mb: 1 }} />
+					  ))
+					: indexList.slice(0, 14).map((s, i, arr) => (
+							<Box key={s.packGuid} sx={{ paddingX: 2.5 }}>
+								<Clickable>
+									<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25 }}>
+											<Typography strong sx={{ flex: 1 }} noWrap>
+												{s.title}
+											</Typography>
+											{s.publishedAt && (
+												<Typography small color="grey.500" noWrap>
+													{getSmartDateAgoString(s.publishedAt)}
+												</Typography>
+											)}
+											<ChevronRightRounded sx={{ color: 'grey.400' }} />
+										</Box>
+									</Link>
+								</Clickable>
+								{i < arr.length - 1 && <Divider />}
+							</Box>
+					  ))}
+			</Box>
+		</>
+	)
+
+	// ------------------------------------------------------------------
+
+	const body =
+		variant === 1
+			? shelvesVariant
+			: variant === 2
+			? gridVariant
+			: variant === 3
+			? editorialVariant
+			: variant === 4
+			? chatVariant
+			: indexVariant
 
 	return (
 		<Box
@@ -339,95 +684,10 @@ function DemoMobilePage() {
 					display: 'flex',
 					flexDirection: 'column',
 					boxShadow: 3,
+					position: 'relative',
 				}}
 			>
-				{/* ===================== HEADER ===================== */}
-				<Box
-					sx={{
-						paddingX: 2.5,
-						paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-						paddingBottom: 3,
-						display: 'flex',
-						justifyContent: 'space-between',
-						alignItems: 'end',
-						...(headerStyle === 'white' && {
-							bgcolor: 'background.paper',
-						}),
-						...(headerStyle === 'lightgrey' && {
-							bgcolor: 'grey.100',
-						}),
-						...(headerStyle === 'dark' && {
-							bgcolor: 'grey.900',
-							color: 'common.white',
-						}),
-						...(headerStyle === 'elevated' && {
-							bgcolor: 'background.paper',
-							boxShadow: 2,
-							position: 'relative',
-							zIndex: 1,
-						}),
-					}}
-				>
-					<Box>
-						<Typography
-							small
-							color={darkHeader ? undefined : 'grey.700'}
-							sx={darkHeader ? { opacity: 0.8 } : {}}
-						>
-							{tHome('hero.lead')}
-						</Typography>
-						<Typography variant="h3" strong={800}>
-							{tHome('hero.title')}
-						</Typography>
-					</Box>
-					{loginButton}
-				</Box>
-
-				{/* ===================== SECTIONS ===================== */}
-				<Box
-					sx={{
-						flex: 1,
-						display: 'flex',
-						flexDirection: 'column',
-						paddingBottom: DOCKED_SEARCH_CLEARANCE,
-					}}
-				>
-					<Section
-						title={tHome('recommended.idea')}
-						surface={recommendedSurface}
-					>
-						{recommendedRows}
-					</Section>
-
-					<Section
-						title={tHome('lastAdded.title')}
-						action={browseAction}
-						surface={lastAddedSurface}
-					>
-						{lastAddedCarousel(
-							lastAddedSurface === 'white' ? 'grey.100' : 'background.paper'
-						)}
-					</Section>
-				</Box>
-
-				{/* ===== Docked search — floats above the tab bar (thumb zone) ===== */}
-				<Box
-					sx={{
-						position: 'fixed',
-						bottom: 'calc(env(safe-area-inset-bottom) + 82px)',
-						left: '50%',
-						transform: 'translateX(-50%)',
-						width: '100%',
-						maxWidth: PAGE_MAX_WIDTH,
-						paddingX: 4,
-						// no global border-box in this app — keep the padding
-						// inside the 100% width instead of overflowing it
-						boxSizing: 'border-box',
-						zIndex: 10,
-					}}
-				>
-					{searchForm}
-				</Box>
+				{body}
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}
 				<Box
@@ -438,7 +698,6 @@ function DemoMobilePage() {
 						transform: 'translateX(-50%)',
 						width: '100%',
 						maxWidth: PAGE_MAX_WIDTH,
-						// translucent + blur like native bars
 						bgcolor: alpha(theme.palette.background.paper, 0.85),
 						backdropFilter: 'blur(12px)',
 						borderTop: '1px solid',
@@ -449,26 +708,13 @@ function DemoMobilePage() {
 					}}
 				>
 					<Link to="demoMobile" params={{ v }} style={{ flex: 1 }}>
-						<TabItem
-							icon={<HomeOutlined />}
-							activeIcon={<HomeRounded />}
-							label={tNav('home')}
-							active
-						/>
+						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active />
 					</Link>
 					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
-						<TabItem
-							icon={<LibraryMusicOutlined />}
-							activeIcon={<LibraryMusicRounded />}
-							label={tNav('songs')}
-						/>
+						<TabItem icon={<LibraryMusicOutlined />} activeIcon={<LibraryMusicRounded />} label={tNav('songs')} />
 					</Link>
 					<Link to="account" params={{}} style={{ flex: 1 }}>
-						<TabItem
-							icon={<PersonOutlineRounded />}
-							activeIcon={<PersonRounded />}
-							label={tNav('account')}
-						/>
+						<TabItem icon={<PersonOutlineRounded />} activeIcon={<PersonRounded />} label={tNav('account')} />
 					</Link>
 				</Box>
 			</Box>
@@ -476,9 +722,29 @@ function DemoMobilePage() {
 	)
 }
 
+/** Fixed pill floating above the tab bar (thumb zone). */
+function DockedSearch({ children }: { children: ReactNode }) {
+	return (
+		<Box
+			sx={{
+				position: 'fixed',
+				bottom: 'calc(env(safe-area-inset-bottom) + 82px)',
+				left: '50%',
+				transform: 'translateX(-50%)',
+				width: '100%',
+				maxWidth: PAGE_MAX_WIDTH,
+				paddingX: 4,
+				boxSizing: 'border-box',
+				zIndex: 10,
+			}}
+		>
+			{children}
+		</Box>
+	)
+}
+
 type TabItemProps = {
 	icon: JSX.Element
-	/** filled counterpart shown when the tab is selected (native pattern) */
 	activeIcon?: JSX.Element
 	label: string
 	active?: boolean

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -3,7 +3,7 @@
 import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
-import { Box, Button, Clickable, Divider, Image, Typography, useTheme } from '@/common/ui'
+import { Box, Clickable, Divider, Image, Typography, useTheme } from '@/common/ui'
 import { Link } from '@/common/ui/Link/Link'
 import { alpha } from '@/common/ui/mui'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
@@ -115,7 +115,7 @@ function DemoMobilePage() {
 						bgcolor: tileBg,
 						borderRadius: 3,
 						padding: 2,
-						boxShadow: variant === 2 ? 0 : 1,
+						boxShadow: 1,
 						scrollSnapAlign: 'start',
 						display: 'flex',
 						flexDirection: 'column',
@@ -443,7 +443,18 @@ function DemoMobilePage() {
 					</Box>
 
 					{/* --- Last added (horizontal carousel) --- */}
-					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+					<Box
+						sx={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 1,
+							// full-bleed grey band separates the section from the white page
+							...(variant === 2 && {
+								bgcolor: 'grey.100',
+								paddingY: 2,
+							}),
+						}}
+					>
 						<Typography variant="h6" strong sx={{ paddingX: 2.5 }}>
 							{tHome('lastAdded.title')}
 						</Typography>
@@ -473,44 +484,13 @@ function DemoMobilePage() {
 									? carouselSkeletons
 									: lastAdded.data
 											.slice(0, 8)
-											.map((s) =>
-												carouselTile(
-													s,
-													variant === 2 ? 'grey.100' : 'background.paper'
-												)
-											)}
+											.map((s) => carouselTile(s, 'background.paper'))}
 							</Box>
 						</Box>
 					</Box>
 
 					{/* --- CTA: browse all songs --- */}
-					{variant === 2 ? (
-						<Box
-							sx={{
-								marginX: 2.5,
-								display: 'flex',
-								flexDirection: 'column',
-								gap: 1.5,
-							}}
-						>
-							<Box>
-								<Typography variant="h6" strong>
-									{tSuggestions('noIdea')}
-								</Typography>
-								<Typography small color="grey.700">
-									{tSuggestions('chooseSuggestion')}
-								</Typography>
-							</Box>
-							<Button
-								to="songsList"
-								toParams={{ s: undefined }}
-								size="large"
-								startIcon={<QueueMusicRounded />}
-							>
-								{tHome('allList.title')}
-							</Button>
-						</Box>
-					) : (
+					{
 						<Box
 							sx={{
 								marginX: 2.5,
@@ -537,7 +517,7 @@ function DemoMobilePage() {
 								<Typography
 									small
 									color={variant === 1 ? 'grey.700' : undefined}
-									sx={variant === 3 ? { opacity: 0.9 } : {}}
+									sx={variant === 1 ? {} : { opacity: 0.9 }}
 								>
 									{tSuggestions('chooseSuggestion')}
 								</Typography>
@@ -571,7 +551,7 @@ function DemoMobilePage() {
 								</Link>
 							</Clickable>
 						</Box>
-					)}
+					}
 				</Box>
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -140,7 +140,7 @@ function DemoMobilePage() {
 							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
 					  ))
 					: rec.slice(0, 5).map((s) => (
-							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1 }} />
+							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
 					  ))}
 			</Box>
 		</Box>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -46,15 +46,18 @@ const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
-type DemoVariant = 1 | 2 | 3
+type DemoVariant = 1 | 2 | 3 | 4
+type SectionStyle = 'card' | 'band' | 'outline' | 'plain'
 
 /**
- * One base design (docked search in the thumb zone, iOS grouped sections,
- * translucent tab bar, no CTA card) with three header treatments:
+ * One base design (gradient header, docked search in the thumb zone,
+ * translucent tab bar, no CTA card) with four section-separation styles:
  *
- * 1 — gradient header: brand gradient band with rounded bottom, white text
- * 2 — tonal header: soft primary tint band, dark text
- * 3 — sheet split: white header, content rides on a grey rounded sheet
+ * 1 — card: white cards with a soft shadow on a grey canvas (baseline)
+ * 2 — band: full-bleed alternating background bands, edge-to-edge rows
+ * 3 — outline: flat white cards with a hairline border, no shadow
+ * 4 — plain: white canvas, sections separated by whitespace + full-width
+ *     hairline dividers only
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -68,18 +71,24 @@ function DemoMobilePage() {
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
 	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 3 ? (parsed as DemoVariant) : 1
+		parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 1
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
 
 	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
 
-	const gradientHeader = variant === 1
-	const tonalHeader = variant === 2
-	const sheetSplit = variant === 3
+	const sectionStyle: SectionStyle = (
+		['card', 'band', 'outline', 'plain'] as const
+	)[variant - 1]
 
-	const canvasBg = sheetSplit ? 'background.paper' : 'grey.100'
+	const canvasBg =
+		sectionStyle === 'card' || sectionStyle === 'outline'
+			? 'grey.100'
+			: 'background.paper'
+	// tiles must contrast with the surface they sit on
+	const tileBg = (sectionBg: 'white' | 'grey') =>
+		sectionBg === 'white' ? 'grey.100' : 'background.paper'
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
@@ -131,11 +140,8 @@ function DemoMobilePage() {
 						width: 42,
 						height: 42,
 						borderRadius: 10,
-						bgcolor: gradientHeader
-							? alpha(theme.palette.common.white, 0.22)
-							: 'background.paper',
-						boxShadow: gradientHeader ? 0 : 1,
-						color: gradientHeader ? 'common.white' : 'primary.main',
+						bgcolor: alpha(theme.palette.common.white, 0.22),
+						color: 'common.white',
 						display: 'flex',
 						alignItems: 'center',
 						justifyContent: 'center',
@@ -147,18 +153,20 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const heroTexts = (
-		<Box>
-			<Typography
-				small
-				color={gradientHeader ? undefined : 'grey.700'}
-				sx={gradientHeader ? { opacity: 0.85 } : {}}
-			>
-				{tHome('hero.lead')}
+	const sectionLabel = (title: string, action?: ReactNode) => (
+		<Box
+			sx={{
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'space-between',
+				gap: 1,
+				paddingX: 0.5,
+			}}
+		>
+			<Typography small strong uppercase color="grey.700">
+				{title.replace(/:$/, '')}
 			</Typography>
-			<Typography variant="h3" strong={800}>
-				{tHome('hero.title')}
-			</Typography>
+			{action}
 		</Box>
 	)
 
@@ -172,61 +180,89 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	// iOS grouped-list section: small uppercase label above a white card
+	// Section wrapper — the separation style is the experiment here
 	const Section = ({
 		title,
 		action,
+		bandBg,
 		children,
 	}: {
 		title: string
 		action?: ReactNode
+		/** band style only: which full-bleed background this section gets */
+		bandBg?: 'white' | 'grey'
 		children: ReactNode
-	}) => (
-		<Box
-			sx={{
-				paddingX: 2.5,
-				display: 'flex',
-				flexDirection: 'column',
-				gap: 1,
-			}}
-		>
+	}) => {
+		if (sectionStyle === 'band') {
+			return (
+				<Box
+					sx={{
+						bgcolor: bandBg === 'grey' ? 'grey.100' : 'background.paper',
+						paddingY: 2.5,
+						paddingX: 2.5,
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 1.5,
+					}}
+				>
+					{sectionLabel(title, action)}
+					{children}
+				</Box>
+			)
+		}
+
+		if (sectionStyle === 'plain') {
+			return (
+				<Box
+					sx={{
+						paddingX: 2.5,
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 1.5,
+					}}
+				>
+					{sectionLabel(title, action)}
+					{children}
+				</Box>
+			)
+		}
+
+		return (
 			<Box
 				sx={{
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'space-between',
-					gap: 1,
-					paddingX: 0.5,
-				}}
-			>
-				<Typography small strong uppercase color="grey.700">
-					{title.replace(/:$/, '')}
-				</Typography>
-				{action}
-			</Box>
-			<Box
-				sx={{
-					bgcolor: 'background.paper',
-					borderRadius: 3,
-					boxShadow: 1,
-					padding: 2,
+					paddingX: 2.5,
 					display: 'flex',
 					flexDirection: 'column',
-					gap: 2,
+					gap: 1,
 				}}
 			>
-				{children}
+				{sectionLabel(title, action)}
+				<Box
+					sx={{
+						bgcolor: 'background.paper',
+						borderRadius: 3,
+						...(sectionStyle === 'card'
+							? { boxShadow: 1 }
+							: { border: '1px solid', borderColor: 'grey.300' }),
+						padding: 2,
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 2,
+					}}
+				>
+					{children}
+				</Box>
 			</Box>
-		</Box>
-	)
+		)
+	}
 
-	const carouselTile = (s: BasicVariantPack) => (
+	const carouselTile = (s: BasicVariantPack, bg: string) => (
 		<Clickable key={s.packGuid}>
 			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
 				<Box
 					sx={{
 						width: 164,
-						bgcolor: 'grey.100',
+						bgcolor: bg,
 						borderRadius: 2,
 						padding: 2,
 						scrollSnapAlign: 'start',
@@ -279,61 +315,49 @@ function DemoMobilePage() {
 		/>
 	))
 
-	const sections = (
+	// carousel bleeds to the section edge; the inset depends on the wrapper
+	const carouselBleed = sectionStyle === 'band' || sectionStyle === 'plain' ? 2.5 : 2
+
+	const recommendedRows = (
+		<Box sx={{ display: 'flex', flexDirection: 'column' }}>
+			{recommended.isLoading
+				? listSkeletons
+				: recommended.data.slice(0, 5).map((s, i, arr) => (
+						<Fragment key={s.packGuid}>
+							<SongVariantCard
+								data={s}
+								dense
+								sx={{ bgcolor: 'transparent', borderRadius: 0 }}
+							/>
+							{i < arr.length - 1 && <Divider sx={{ marginX: 1 }} />}
+						</Fragment>
+				  ))}
+		</Box>
+	)
+
+	const lastAddedCarousel = (tilesBg: string) => (
 		<Box
 			sx={{
-				flex: 1,
 				display: 'flex',
-				flexDirection: 'column',
-				gap: 2.5,
-				paddingTop: 2.5,
-				paddingBottom: DOCKED_SEARCH_CLEARANCE,
+				gap: 1.5,
+				overflowX: 'auto',
+				marginX: -carouselBleed,
+				paddingLeft: carouselBleed,
+				paddingY: 0.5,
+				scrollSnapType: 'x mandatory',
+				scrollPaddingLeft: theme.spacing(carouselBleed),
+				'&::-webkit-scrollbar': { display: 'none' },
+				// keeps the right inset visible at the end of the scroll
+				// (trailing padding collapses in overflow containers)
+				'&::after': {
+					content: '""',
+					flex: '0 0 1px',
+				},
 			}}
 		>
-			<Section title={tHome('recommended.idea')}>
-				<Box sx={{ display: 'flex', flexDirection: 'column' }}>
-					{recommended.isLoading
-						? listSkeletons
-						: recommended.data.slice(0, 5).map((s, i, arr) => (
-								<Fragment key={s.packGuid}>
-									<SongVariantCard
-										data={s}
-										dense
-										sx={{ bgcolor: 'transparent', borderRadius: 0 }}
-									/>
-									{i < arr.length - 1 && <Divider sx={{ marginX: 1 }} />}
-								</Fragment>
-						  ))}
-				</Box>
-			</Section>
-
-			<Section title={tHome('lastAdded.title')} action={browseAction}>
-				<Box
-					sx={{
-						display: 'flex',
-						gap: 1.5,
-						overflowX: 'auto',
-						// bleed the scroll area to the panel edges, then restore
-						// the inset inside it so tiles align with the header text
-						marginX: -2,
-						paddingLeft: 2,
-						paddingY: 0.5,
-						scrollSnapType: 'x mandatory',
-						scrollPaddingLeft: theme.spacing(2),
-						'&::-webkit-scrollbar': { display: 'none' },
-						// keeps the right inset visible at the end of the scroll
-						// (trailing padding collapses in overflow containers)
-						'&::after': {
-							content: '""',
-							flex: '0 0 1px',
-						},
-					}}
-				>
-					{lastAdded.isLoading
-						? carouselSkeletons
-						: lastAdded.data.slice(0, 8).map((s) => carouselTile(s))}
-				</Box>
-			</Section>
+			{lastAdded.isLoading
+				? carouselSkeletons
+				: lastAdded.data.slice(0, 8).map((s) => carouselTile(s, tilesBg))}
 		</Box>
 	)
 
@@ -368,43 +392,58 @@ function DemoMobilePage() {
 					sx={{
 						paddingX: 2.5,
 						paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-						paddingBottom: gradientHeader || tonalHeader ? 3.5 : 1,
+						paddingBottom: 3.5,
 						display: 'flex',
 						justifyContent: 'space-between',
 						alignItems: 'end',
-						...(gradientHeader && {
-							background: gradient,
-							color: 'common.white',
-							borderRadius: '0 0 28px 28px',
-						}),
-						...(tonalHeader && {
-							bgcolor: alpha(theme.palette.primary.main, 0.09),
-							borderRadius: '0 0 28px 28px',
-						}),
+						background: gradient,
+						color: 'common.white',
+						borderRadius: sectionStyle === 'band' ? 0 : '0 0 28px 28px',
 					}}
 				>
-					{heroTexts}
+					<Box>
+						<Typography small sx={{ opacity: 0.85 }}>
+							{tHome('hero.lead')}
+						</Typography>
+						<Typography variant="h3" strong={800}>
+							{tHome('hero.title')}
+						</Typography>
+					</Box>
 					{loginButton}
 				</Box>
 
-				{/* ===================== CONTENT ===================== */}
-				{sheetSplit ? (
-					// content rides on a grey rounded sheet over the white canvas
-					<Box
-						sx={{
-							flex: 1,
-							marginTop: 2,
-							bgcolor: 'grey.100',
-							borderRadius: '28px 28px 0 0',
-							display: 'flex',
-							flexDirection: 'column',
-						}}
+				{/* ===================== SECTIONS ===================== */}
+				<Box
+					sx={{
+						flex: 1,
+						display: 'flex',
+						flexDirection: 'column',
+						gap:
+							sectionStyle === 'band' ? 0 : sectionStyle === 'plain' ? 3 : 2.5,
+						paddingTop: sectionStyle === 'band' ? 0 : 2.5,
+						paddingBottom: DOCKED_SEARCH_CLEARANCE,
+					}}
+				>
+					<Section title={tHome('recommended.idea')} bandBg="grey">
+						{recommendedRows}
+					</Section>
+
+					{sectionStyle === 'plain' && <Divider />}
+
+					<Section
+						title={tHome('lastAdded.title')}
+						action={browseAction}
+						bandBg="white"
 					>
-						{sections}
-					</Box>
-				) : (
-					sections
-				)}
+						{lastAddedCarousel(
+							sectionStyle === 'card' || sectionStyle === 'outline'
+								? 'grey.100'
+								: sectionStyle === 'band'
+								? tileBg('white')
+								: tileBg('white')
+						)}
+					</Section>
+				</Box>
 
 				{/* ===== Docked search — floats above the tab bar (thumb zone) ===== */}
 				<Box

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -42,12 +42,12 @@ type DemoVariant = 1 | 2 | 3
 
 /**
  * Grey canvas + white cards for the picks (the liked G3 look). The recent
- * section stays a QUIET airy list (chips were dropped — they read like
- * filter tags). Variants only fine-tune the list row:
+ * section is the L3 airy list (title + date + chevron). Variants only turn
+ * DOWN its prominence so it recedes further under the picks:
  *
- * 1 — titles only: the quietest, just names
- * 2 — title + date: a muted date on the right
- * 3 — title + date + chevron: same, with a tap affordance
+ * 1 — subtle: dark-grey titles
+ * 2 — muted: smaller, grey titles (default)
+ * 3 — faint: small thin light-grey titles, barely there
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -147,24 +147,23 @@ function DemoMobilePage() {
 			))
 		}
 
-		// airy transparent rows — 1 titles only, 2 + date, 3 + date + chevron
-		const withDate = variant !== 1
-		const withChevron = variant === 3
+		// airy list (title + date + chevron), dialled DOWN by mute level
+		const titleColor = variant === 1 ? 'grey.700' : variant === 2 ? 'grey.600' : 'grey.500'
+		const titleSmall = variant >= 2
+		const titleThin = variant === 3
 		return (
-			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: variant === 1 ? 0.5 : 0.25 }}>
 				{last.slice(0, 5).map((s) => (
 					<Clickable key={s.packGuid}>
 						<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-							<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1 }}>
-								<Typography color="grey.800" noWrap sx={{ flex: 1 }}>
+							<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: variant === 1 ? 1 : 0.75 }}>
+								<Typography small={titleSmall} thin={titleThin} color={titleColor} noWrap sx={{ flex: 1 }}>
 									{s.title}
 								</Typography>
-								{withDate && (
-									<Typography small color="grey.500" noWrap>
-										{dateOf(s.publishedAt)}
-									</Typography>
-								)}
-								{withChevron && <ChevronRightRounded sx={{ color: 'grey.400' }} />}
+								<Typography small color="grey.400" noWrap>
+									{dateOf(s.publishedAt)}
+								</Typography>
+								<ChevronRightRounded fontSize="small" sx={{ color: 'grey.300' }} />
 							</Box>
 						</Link>
 					</Clickable>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -14,7 +14,6 @@ import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
-	ArrowForwardRounded,
 	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
@@ -45,14 +44,14 @@ type DemoVariant = 1 | 2 | 3 | 4
 
 /**
  * Grey canvas + white cards for the picks; the recent section is the quiet
- * airy list (subtle M1 look). The SEARCH is a white, mostly-squared field
- * with a short placeholder and a SMALL blue submit button so it stands out
- * without crowding the text — variants only tune that button:
+ * airy list (subtle M1 look). The SEARCH has NO button — instead a primary
+ * gradient border (same look as the desktop MainSearchInput) draws the eye,
+ * with the full placeholder. Variants tune the border + inner field:
  *
- * 1 — small squared blue button + arrow (default, matches the angular field)
- * 2 — small squared blue button + search icon
- * 3 — small circular blue button + arrow
- * 4 — sharp (barely-rounded) field + squared button
+ * 1 — thin gradient border, white inner field (default)
+ * 2 — thicker gradient border, white inner field
+ * 3 — thin gradient border, subtle grey inner field (matches desktop)
+ * 4 — thin gradient border, white inner field, primary-tinted search icon
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -185,11 +184,11 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// ---- search: white, angular field + a SMALL blue submit button ---
+	// ---- search: no button, primary gradient border draws the eye ----
 
-	const roundButton = variant === 3 // 3 = circle button, others squared
-	const fieldRadius = variant === 4 ? 1 : 1.5 // 4 = sharper corners
-	const buttonIcon = variant === 2 ? <SearchRounded sx={{ fontSize: 18 }} /> : <ArrowForwardRounded sx={{ fontSize: 18 }} />
+	const borderThickness = variant === 2 ? '3px' : '2px'
+	const innerBg = variant === 3 ? 'grey.50' : 'background.paper'
+	const iconColor = variant === 4 ? 'primary.main' : 'grey.500'
 
 	const search = (
 		<Box
@@ -199,44 +198,28 @@ function DemoMobilePage() {
 				submit()
 			}}
 			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				gap: 1,
-				bgcolor: 'background.paper',
-				border: '1px solid',
-				borderColor: 'grey.200',
-				borderRadius: fieldRadius,
+				background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
+				borderRadius: 2,
+				padding: borderThickness,
 				boxShadow: 2,
-				paddingLeft: 1.75,
-				paddingRight: 0.75,
-				paddingY: 0.75,
-				minWidth: 0,
 			}}
 		>
-			<SearchRounded sx={{ color: 'grey.500', fontSize: 20 }} />
-			<Box sx={{ flex: 1, minWidth: 0 }}>
-				<TextField value={query} onChange={setQuery} placeholder={tSearch('searchSongs')} />
-			</Box>
 			<Box
-				role="button"
-				aria-label={tSearch('searchSongs')}
-				onClick={submit}
 				sx={{
-					width: 32,
-					height: 32,
-					flexShrink: 0,
-					borderRadius: roundButton ? 10 : 1,
-					bgcolor: 'primary.main',
-					color: 'common.white',
 					display: 'flex',
 					alignItems: 'center',
-					justifyContent: 'center',
-					cursor: 'pointer',
-					transition: 'background-color 0.15s',
-					'&:hover': { bgcolor: 'primary.dark' },
+					gap: 1,
+					bgcolor: innerBg,
+					borderRadius: 1.75,
+					paddingX: 1.75,
+					paddingY: 1.25,
+					minWidth: 0,
 				}}
 			>
-				{buttonIcon}
+				<SearchRounded sx={{ color: iconColor, fontSize: 20 }} />
+				<Box sx={{ flex: 1, minWidth: 0 }}>
+					<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
+				</Box>
 			</Box>
 		</Box>
 	)

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -1,0 +1,664 @@
+'use client'
+
+import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
+import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
+import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
+import { Box, Button, Clickable, Divider, Image, Typography, useTheme } from '@/common/ui'
+import { Link } from '@/common/ui/Link/Link'
+import { alpha } from '@/common/ui/mui'
+import { Skeleton } from '@/common/ui/mui/Skeleton'
+import { SongVariantCard } from '@/common/ui/SongCard'
+import { TextField } from '@/common/ui/TextField'
+import { useSmartNavigate } from '@/routes/useSmartNavigate'
+import { useSmartParams } from '@/routes/useSmartParams'
+import { getSmartDateAgoString } from '@/tech/date/date.tech'
+import { getAssetUrl } from '@/tech/paths.tech'
+import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
+import {
+	HomeRounded,
+	LoginRounded,
+	MusicNoteRounded,
+	PersonOutlineRounded,
+	QueueMusicRounded,
+	SearchRounded,
+} from '@mui/icons-material'
+import { useTranslations } from 'next-intl'
+import { Fragment, useState } from 'react'
+import { BasicVariantPack } from '../../../api/dtos'
+
+export default SmartPage(DemoMobilePage, [
+	'hideToolbar',
+	'hideFooter',
+	'hideTitle',
+	'fullWidth',
+	'hidePadding',
+])
+
+const PAGE_MAX_WIDTH = 480
+const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
+const BOTTOM_NAV_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
+
+type DemoVariant = 1 | 2 | 3
+
+function DemoMobilePage() {
+	const theme = useTheme()
+	const tHome = useTranslations('home')
+	const tNav = useTranslations('navigation')
+	const tSearch = useTranslations('search')
+	const tSuggestions = useTranslations('suggestions')
+
+	const navigate = useSmartNavigate()
+	const [query, setQuery] = useState('')
+
+	const { v } = useSmartParams('demoMobile')
+	const variant: DemoVariant = Number(v) === 2 ? 2 : Number(v) === 3 ? 3 : 1
+
+	const recommended = useRecommendedSongs()
+	const lastAdded = useLastAddedSongs()
+
+	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
+
+	const submitSearch = (e: React.FormEvent) => {
+		e.preventDefault()
+		if (query.trim().length > 0) {
+			navigate('home', { hledat: query.trim() })
+		}
+	}
+
+	const searchField = (
+		<>
+			<SearchRounded sx={{ color: 'grey.600' }} />
+			<TextField
+				value={query}
+				onChange={setQuery}
+				placeholder={tSearch('searchByTitleOrText')}
+			/>
+		</>
+	)
+
+	const loginLink = (textColor: string) => (
+		<Clickable>
+			<Link to="login" params={{ previousPage: '', message: '' }}>
+				<Box
+					sx={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 0.5,
+						color: textColor,
+						paddingY: 0.5,
+					}}
+				>
+					<Typography small strong uppercase>
+						{tNav('login')}
+					</Typography>
+					<LoginRounded fontSize="small" />
+				</Box>
+			</Link>
+		</Clickable>
+	)
+
+	const sheep = (size: number) => (
+		<Image
+			src={getAssetUrl('/sheeps/ovce3.svg')}
+			alt={tSuggestions('sheep')}
+			width={size}
+			height={size}
+		/>
+	)
+
+	const carouselTile = (s: BasicVariantPack, tileBg: string) => (
+		<Clickable key={s.packGuid}>
+			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+				<Box
+					sx={{
+						width: 168,
+						bgcolor: tileBg,
+						borderRadius: 3,
+						padding: 2,
+						boxShadow: variant === 2 ? 0 : 1,
+						scrollSnapAlign: 'start',
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 1,
+					}}
+				>
+					<Box
+						sx={{
+							width: 36,
+							height: 36,
+							borderRadius: 2,
+							bgcolor: alpha(theme.palette.primary.main, 0.12),
+							color: 'primary.main',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+						}}
+					>
+						<MusicNoteRounded fontSize="small" />
+					</Box>
+					<Typography strong noWrap>
+						{s.title}
+					</Typography>
+					{s.publishedAt && (
+						<Typography small color="grey.700">
+							{getSmartDateAgoString(s.publishedAt)}
+						</Typography>
+					)}
+				</Box>
+			</Link>
+		</Clickable>
+	)
+
+	const carouselSkeletons = Array.from({ length: 4 }).map((_, i) => (
+		<Skeleton
+			key={i}
+			variant="rounded"
+			sx={{
+				minWidth: 168,
+				height: 120,
+				borderRadius: 3,
+				bgcolor: 'grey.200',
+			}}
+		/>
+	))
+
+	const listSkeletons = Array.from({ length: 4 }).map((_, i) => (
+		<Skeleton
+			key={i}
+			variant="rounded"
+			sx={{ height: 64, borderRadius: 2, bgcolor: 'grey.200' }}
+		/>
+	))
+
+	return (
+		<Box
+			sx={{
+				// width 0 + minWidth 100% stops the column's maxWidth from
+				// propagating as min-content through the flex app layout
+				width: 0,
+				minWidth: '100%',
+				marginTop: `calc(-1 * ${TOOLBAR_SPACER})`,
+				minHeight: '100dvh',
+				bgcolor: variant === 2 ? 'grey.200' : 'grey.300',
+				display: 'flex',
+				justifyContent: 'center',
+			}}
+		>
+			<Box
+				sx={{
+					width: '100%',
+					maxWidth: PAGE_MAX_WIDTH,
+					minWidth: 0,
+					minHeight: '100dvh',
+					bgcolor:
+						variant === 1 ? 'grey.100' : variant === 2 ? 'background.paper' : 'background.paper',
+					display: 'flex',
+					flexDirection: 'column',
+					boxShadow: 3,
+				}}
+			>
+				{/* ===================== HEADER ===================== */}
+				{variant === 1 && (
+					<>
+						<Box
+							sx={{
+								background: gradient,
+								color: 'common.white',
+								paddingX: 2.5,
+								paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
+								paddingBottom: 8,
+								position: 'relative',
+								overflow: 'hidden',
+							}}
+						>
+							<Box
+								sx={{
+									position: 'absolute',
+									right: 12,
+									bottom: -6,
+									transform: 'rotate(-8deg)',
+									pointerEvents: 'none',
+									opacity: 0.9,
+								}}
+							>
+								{sheep(76)}
+							</Box>
+							<Box
+								sx={{
+									display: 'flex',
+									justifyContent: 'space-between',
+									alignItems: 'start',
+								}}
+							>
+								<Box>
+									<Typography small sx={{ opacity: 0.85 }}>
+										{tHome('hero.lead')}
+									</Typography>
+									<Typography variant="h4" strong={800}>
+										{tHome('hero.title')}
+									</Typography>
+								</Box>
+								{loginLink('common.white')}
+							</Box>
+						</Box>
+
+						<Box
+							component="form"
+							onSubmit={submitSearch}
+							sx={{
+								marginTop: -3.5,
+								marginX: 2.5,
+								position: 'relative',
+								zIndex: 1,
+								display: 'flex',
+								alignItems: 'center',
+								gap: 1,
+								bgcolor: 'background.paper',
+								borderRadius: 3,
+								paddingX: 2,
+								paddingY: 1.5,
+								boxShadow: 2,
+							}}
+						>
+							{searchField}
+						</Box>
+					</>
+				)}
+
+				{variant === 2 && (
+					<Box
+						sx={{
+							paddingX: 2.5,
+							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 2,
+						}}
+					>
+						<Box
+							sx={{
+								display: 'flex',
+								justifyContent: 'space-between',
+								alignItems: 'end',
+							}}
+						>
+							<Box>
+								<Typography small color="grey.700">
+									{tHome('hero.lead')}
+								</Typography>
+								<Typography variant="h3" strong={800}>
+									{tHome('hero.title')}
+								</Typography>
+							</Box>
+							{loginLink('primary.main')}
+						</Box>
+
+						<Box
+							component="form"
+							onSubmit={submitSearch}
+							sx={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 1,
+								bgcolor: 'grey.100',
+								borderRadius: 10,
+								paddingX: 2,
+								paddingY: 1.25,
+							}}
+						>
+							{searchField}
+						</Box>
+					</Box>
+				)}
+
+				{variant === 3 && (
+					<Box
+						sx={{
+							bgcolor: 'primary.main',
+							color: 'common.white',
+							paddingX: 2.5,
+							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
+							paddingBottom: 3,
+							borderRadius: '0 0 28px 28px',
+							position: 'relative',
+							overflow: 'hidden',
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 2,
+						}}
+					>
+						<Box
+							sx={{
+								position: 'absolute',
+								right: 10,
+								top: 'calc(env(safe-area-inset-top) + 10px)',
+								pointerEvents: 'none',
+							}}
+						>
+							{sheep(64)}
+						</Box>
+						<Box>
+							<Typography small sx={{ opacity: 0.85 }}>
+								{tHome('hero.lead')}
+							</Typography>
+							<Typography variant="h4" strong={800}>
+								{tHome('hero.title')}
+							</Typography>
+						</Box>
+						<Box
+							component="form"
+							onSubmit={submitSearch}
+							sx={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 1,
+								bgcolor: 'background.paper',
+								borderRadius: 10,
+								paddingX: 2,
+								paddingY: 1.25,
+							}}
+						>
+							{searchField}
+						</Box>
+					</Box>
+				)}
+
+				{/* ===================== CONTENT ===================== */}
+				<Box
+					sx={{
+						flex: 1,
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 3,
+						paddingTop: 3,
+						paddingBottom: BOTTOM_NAV_CLEARANCE,
+					}}
+				>
+					{/* --- Recommended songs --- */}
+					<Box
+						sx={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 1,
+							paddingX: 2.5,
+						}}
+					>
+						<Typography variant="h6" strong>
+							{tHome('recommended.idea')}
+						</Typography>
+
+						{variant === 2 ? (
+							<Box
+								sx={{
+									bgcolor: 'grey.100',
+									borderRadius: 3,
+									overflow: 'hidden',
+									display: 'flex',
+									flexDirection: 'column',
+								}}
+							>
+								{recommended.isLoading
+									? listSkeletons
+									: recommended.data.slice(0, 4).map((v, i, arr) => (
+											<Fragment key={v.packGuid}>
+												<SongVariantCard
+													data={v}
+													dense
+													sx={{ bgcolor: 'transparent', borderRadius: 0 }}
+												/>
+												{i < arr.length - 1 && (
+													<Divider sx={{ marginX: 2 }} />
+												)}
+											</Fragment>
+									  ))}
+							</Box>
+						) : (
+							<Box
+								sx={{
+									...(variant === 3 && {
+										bgcolor: alpha(theme.palette.primary.main, 0.07),
+										borderRadius: 3,
+										padding: 1.5,
+									}),
+									display: 'flex',
+									flexDirection: 'column',
+									gap: 1,
+								}}
+							>
+								{recommended.isLoading
+									? listSkeletons
+									: recommended.data.slice(0, 4).map((v) => (
+											<SongVariantCard
+												key={v.packGuid}
+												data={v}
+												dense
+												sx={{
+													bgcolor: 'background.paper',
+													boxShadow: 1,
+												}}
+											/>
+									  ))}
+							</Box>
+						)}
+					</Box>
+
+					{/* --- Last added (horizontal carousel) --- */}
+					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+						<Typography variant="h6" strong sx={{ paddingX: 2.5 }}>
+							{tHome('lastAdded.title')}
+						</Typography>
+
+						<Box
+							sx={{
+								...(variant === 3 && {
+									bgcolor: alpha(theme.palette.secondary.main, 0.14),
+									borderRadius: 3,
+									marginX: 2.5,
+									paddingX: 1.5,
+								}),
+							}}
+						>
+							<Box
+								sx={{
+									display: 'flex',
+									gap: 1.5,
+									overflowX: 'auto',
+									paddingX: variant === 3 ? 0 : 2.5,
+									paddingY: variant === 3 ? 1.5 : 1,
+									scrollSnapType: 'x mandatory',
+									'&::-webkit-scrollbar': { display: 'none' },
+								}}
+							>
+								{lastAdded.isLoading
+									? carouselSkeletons
+									: lastAdded.data
+											.slice(0, 8)
+											.map((s) =>
+												carouselTile(
+													s,
+													variant === 2 ? 'grey.100' : 'background.paper'
+												)
+											)}
+							</Box>
+						</Box>
+					</Box>
+
+					{/* --- CTA: browse all songs --- */}
+					{variant === 2 ? (
+						<Box
+							sx={{
+								marginX: 2.5,
+								display: 'flex',
+								flexDirection: 'column',
+								gap: 1.5,
+							}}
+						>
+							<Box>
+								<Typography variant="h6" strong>
+									{tSuggestions('noIdea')}
+								</Typography>
+								<Typography small color="grey.700">
+									{tSuggestions('chooseSuggestion')}
+								</Typography>
+							</Box>
+							<Button
+								to="songsList"
+								toParams={{ s: undefined }}
+								size="large"
+								startIcon={<QueueMusicRounded />}
+							>
+								{tHome('allList.title')}
+							</Button>
+						</Box>
+					) : (
+						<Box
+							sx={{
+								marginX: 2.5,
+								...(variant === 1
+									? {
+											bgcolor: 'background.paper',
+											boxShadow: 1,
+									  }
+									: {
+											background: gradient,
+											color: 'common.white',
+									  }),
+								borderRadius: 3,
+								padding: 2.5,
+								display: 'flex',
+								flexDirection: 'column',
+								gap: 1.5,
+							}}
+						>
+							<Box>
+								<Typography variant="h6" strong>
+									{tSuggestions('noIdea')}
+								</Typography>
+								<Typography
+									small
+									color={variant === 1 ? 'grey.700' : undefined}
+									sx={variant === 3 ? { opacity: 0.9 } : {}}
+								>
+									{tSuggestions('chooseSuggestion')}
+								</Typography>
+							</Box>
+							<Clickable>
+								<Link to="songsList" params={{ s: undefined }}>
+									<Box
+										sx={{
+											...(variant === 1
+												? {
+														background: gradient,
+														color: 'common.white',
+												  }
+												: {
+														bgcolor: 'background.paper',
+														color: 'primary.main',
+												  }),
+											borderRadius: 2,
+											paddingY: 1.5,
+											display: 'flex',
+											alignItems: 'center',
+											justifyContent: 'center',
+											gap: 1,
+										}}
+									>
+										<QueueMusicRounded fontSize="small" />
+										<Typography small strong uppercase>
+											{tHome('allList.title')}
+										</Typography>
+									</Box>
+								</Link>
+							</Clickable>
+						</Box>
+					)}
+				</Box>
+
+				{/* ===================== BOTTOM TAB BAR ===================== */}
+				<Box
+					sx={{
+						position: 'fixed',
+						bottom: 0,
+						left: '50%',
+						transform: 'translateX(-50%)',
+						width: '100%',
+						maxWidth: PAGE_MAX_WIDTH,
+						bgcolor: 'background.paper',
+						borderTop: '1px solid',
+						borderColor: 'grey.300',
+						display: 'flex',
+						paddingBottom: 'env(safe-area-inset-bottom)',
+						zIndex: 10,
+					}}
+				>
+					<Link to="demoMobile" params={{ v }} style={{ flex: 1 }}>
+						<TabItem
+							icon={<HomeRounded />}
+							label={tNav('home')}
+							active
+							pill={variant === 3}
+						/>
+					</Link>
+					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
+						<TabItem
+							icon={<QueueMusicRounded />}
+							label={tNav('songs')}
+							pill={variant === 3}
+						/>
+					</Link>
+					<Link to="account" params={{}} style={{ flex: 1 }}>
+						<TabItem
+							icon={<PersonOutlineRounded />}
+							label={tNav('account')}
+							pill={variant === 3}
+						/>
+					</Link>
+				</Box>
+			</Box>
+		</Box>
+	)
+}
+
+type TabItemProps = {
+	icon: JSX.Element
+	label: string
+	active?: boolean
+	/** Material-3-like tonal pill behind the active icon */
+	pill?: boolean
+}
+
+function TabItem({ icon, label, active, pill }: TabItemProps) {
+	const theme = useTheme()
+	return (
+		<Box
+			sx={{
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+				gap: 0.25,
+				paddingY: 1,
+				color: active ? 'primary.main' : 'grey.700',
+			}}
+		>
+			<Box
+				sx={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					...(pill && {
+						paddingX: 2,
+						borderRadius: 10,
+						bgcolor: active
+							? alpha(theme.palette.primary.main, 0.14)
+							: 'transparent',
+					}),
+				}}
+			>
+				{icon}
+			</Box>
+			<Typography small strong={active ? 700 : 400}>
+				{label}
+			</Typography>
+		</Box>
+	)
+}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -48,7 +48,7 @@ const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const BOTTOM_NAV_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
 
-type DemoVariant = 1 | 2 | 3
+type DemoVariant = 1 | 2 | 3 | 4 | 5
 
 /**
  * Three internally consistent design systems, all sharing the same page
@@ -62,6 +62,10 @@ type DemoVariant = 1 | 2 | 3
  *     identical grey panels on white
  * 3 — blue system: white canvas, one accent (primary), tonal panels and
  *     icon-badged section headers, M3-style tab pills
+ *
+ * Thumb-reach experiments (no last-added section, search within thumb zone):
+ * 4 — centered search: hero pushes the search to mid-screen
+ * 5 — docked search: search floats just above the bottom tab bar
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -74,7 +78,11 @@ function DemoMobilePage() {
 	const [query, setQuery] = useState('')
 
 	const { v } = useSmartParams('demoMobile')
-	const variant: DemoVariant = Number(v) === 2 ? 2 : Number(v) === 3 ? 3 : 1
+	const parsed = Number(v)
+	const variant: DemoVariant =
+		parsed === 2 || parsed === 3 || parsed === 4 || parsed === 5
+			? (parsed as DemoVariant)
+			: 1
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
@@ -86,13 +94,14 @@ function DemoMobilePage() {
 	const panelBg =
 		variant === 1
 			? 'background.paper'
-			: variant === 2
-			? 'grey.100'
-			: primaryTint
+			: variant === 3
+			? primaryTint
+			: 'grey.100'
 	const panelShadow = variant === 1 ? 1 : 0
 	const rowsHaveDividers = variant === 1
 	const rowBg = variant === 1 ? 'transparent' : 'background.paper'
 	const tileBg = variant === 1 ? 'grey.100' : 'background.paper'
+	const showLastAdded = variant <= 3
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
@@ -112,6 +121,53 @@ function DemoMobilePage() {
 				placeholder={tSearch('searchByTitleOrText')}
 			/>
 		</>
+	)
+
+	// gradient border + shadow make the search the strongest element
+	const gradientSearchForm = (
+		<Box
+			sx={{
+				background: gradient,
+				padding: '2px',
+				borderRadius: 10,
+				boxShadow: 3,
+			}}
+		>
+			<Box
+				component="form"
+				onSubmit={submitSearch}
+				sx={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 1,
+					bgcolor: 'background.paper',
+					borderRadius: 10,
+					paddingX: 2,
+					paddingY: 1.5,
+				}}
+			>
+				{searchInner}
+			</Box>
+		</Box>
+	)
+
+	// tonal filled field — the only saturated icon on the page
+	const tonalSearchForm = (
+		<Box
+			component="form"
+			onSubmit={submitSearch}
+			sx={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 1,
+				bgcolor: alpha(theme.palette.primary.main, 0.08),
+				borderRadius: 10,
+				paddingX: 2,
+				paddingY: 1.5,
+			}}
+		>
+			{searchInner}
+		</Box>
 	)
 
 	const loginLink = (textColor: string) => (
@@ -400,6 +456,43 @@ function DemoMobilePage() {
 							{searchInner}
 						</Box>
 					</Box>
+				) : variant === 4 ? (
+					// hero fills the upper half so the search lands mid-screen,
+					// inside comfortable thumb reach
+					<Box
+						sx={{
+							paddingX: 2.5,
+							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
+							height: '52dvh',
+							display: 'flex',
+							flexDirection: 'column',
+							justifyContent: 'space-between',
+							gap: 2.5,
+						}}
+					>
+						<Box
+							sx={{
+								display: 'flex',
+								justifyContent: 'space-between',
+								alignItems: 'end',
+							}}
+						>
+							{heroTexts('grey.700')}
+							{loginLink('primary.main')}
+						</Box>
+						<Box
+							sx={{
+								flex: 1,
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								pointerEvents: 'none',
+							}}
+						>
+							{sheep(128)}
+						</Box>
+						{gradientSearchForm}
+					</Box>
 				) : (
 					<Box
 						sx={{
@@ -421,50 +514,8 @@ function DemoMobilePage() {
 							{loginLink('primary.main')}
 						</Box>
 
-						{variant === 1 ? (
-							// gradient border + shadow make the search the strongest element
-							<Box
-								sx={{
-									background: gradient,
-									padding: '2px',
-									borderRadius: 10,
-									boxShadow: 3,
-								}}
-							>
-								<Box
-									component="form"
-									onSubmit={submitSearch}
-									sx={{
-										display: 'flex',
-										alignItems: 'center',
-										gap: 1,
-										bgcolor: 'background.paper',
-										borderRadius: 10,
-										paddingX: 2,
-										paddingY: 1.5,
-									}}
-								>
-									{searchInner}
-								</Box>
-							</Box>
-						) : (
-							// tonal filled field — the only saturated icon on the page
-							<Box
-								component="form"
-								onSubmit={submitSearch}
-								sx={{
-									display: 'flex',
-									alignItems: 'center',
-									gap: 1,
-									bgcolor: alpha(theme.palette.primary.main, 0.08),
-									borderRadius: 10,
-									paddingX: 2,
-									paddingY: 1.5,
-								}}
-							>
-								{searchInner}
-							</Box>
-						)}
+						{variant === 1 && gradientSearchForm}
+						{variant === 3 && tonalSearchForm}
 					</Box>
 				)}
 
@@ -476,7 +527,11 @@ function DemoMobilePage() {
 						flexDirection: 'column',
 						gap: 2.5,
 						paddingTop: 2.5,
-						paddingBottom: BOTTOM_NAV_CLEARANCE,
+						// v5 also needs room for the docked search bar
+						paddingBottom:
+							variant === 5
+								? 'calc(env(safe-area-inset-bottom) + 156px)'
+								: BOTTOM_NAV_CLEARANCE,
 					}}
 				>
 					<Section
@@ -486,7 +541,7 @@ function DemoMobilePage() {
 						<Box sx={{ display: 'flex', flexDirection: 'column', gap: rowsHaveDividers ? 0 : 1 }}>
 							{recommended.isLoading
 								? listSkeletons
-								: recommended.data.slice(0, 4).map((s, i, arr) => (
+								: recommended.data.slice(0, showLastAdded ? 4 : 6).map((s, i, arr) => (
 										<Fragment key={s.packGuid}>
 											<SongVariantCard
 												data={s}
@@ -504,6 +559,7 @@ function DemoMobilePage() {
 						</Box>
 					</Section>
 
+					{showLastAdded && (
 					<Section
 						title={tHome('lastAdded.title')}
 						icon={<ScheduleRounded sx={{ fontSize: 18 }} />}
@@ -535,6 +591,7 @@ function DemoMobilePage() {
 								: lastAdded.data.slice(0, 8).map((s) => carouselTile(s))}
 						</Box>
 					</Section>
+					)}
 
 					{/* ===================== CTA ===================== */}
 					{variant === 3 ? (
@@ -624,6 +681,24 @@ function DemoMobilePage() {
 						</Box>
 					)}
 				</Box>
+
+				{/* ===== Docked search — floats above the tab bar (thumb zone) ===== */}
+				{variant === 5 && (
+					<Box
+						sx={{
+							position: 'fixed',
+							bottom: 'calc(env(safe-area-inset-bottom) + 72px)',
+							left: '50%',
+							transform: 'translateX(-50%)',
+							width: '100%',
+							maxWidth: PAGE_MAX_WIDTH,
+							paddingX: 2,
+							zIndex: 10,
+						}}
+					>
+						{gradientSearchForm}
+					</Box>
+				)}
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}
 				<Box

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -13,6 +13,7 @@ import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
+	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
 	LibraryMusicOutlined,
@@ -37,17 +38,16 @@ const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const TAB_BAR = 'calc(env(safe-area-inset-bottom) + 64px)'
 const CONTENT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 176px)'
 
-type DemoVariant = 1 | 2 | 3 | 4
+type DemoVariant = 1 | 2 | 3
 
 /**
  * Grey canvas + white cards for the picks (the liked G3 look). The recent
- * section stays QUIET; these variants refine the two liked directions —
- * the airy list and the chips:
+ * section stays a QUIET airy list (chips were dropped — they read like
+ * filter tags). Variants only fine-tune the list row:
  *
- * 1 — airy list with date: spaced muted rows, title + date
- * 2 — airy list, titles only: even cleaner, no dates
- * 3 — chips outlined: small bordered title chips that wrap
- * 4 — chips filled: soft grey filled chips, no border
+ * 1 — titles only: the quietest, just names
+ * 2 — title + date: a muted date on the right
+ * 3 — title + date + chevron: same, with a tap affordance
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -64,7 +64,7 @@ function DemoMobilePage() {
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	const variant: DemoVariant = parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 1
+	const variant: DemoVariant = parsed >= 1 && parsed <= 3 ? (parsed as DemoVariant) : 2
 
 	// ---- header ------------------------------------------------------
 
@@ -147,37 +147,9 @@ function DemoMobilePage() {
 			))
 		}
 
-		// 3 & 4 — title chips (3 outlined, 4 soft filled)
-		if (variant === 3 || variant === 4) {
-			const filled = variant === 4
-			return (
-				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-					{last.slice(0, 6).map((s) => (
-						<Clickable key={s.packGuid}>
-							<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-								<Box
-									sx={{
-										borderRadius: 10,
-										paddingX: 1.75,
-										paddingY: 0.75,
-										...(filled
-											? { bgcolor: 'grey.200' }
-											: { border: '1px solid', borderColor: 'grey.300' }),
-									}}
-								>
-									<Typography small color="grey.700" noWrap>
-										{s.title}
-									</Typography>
-								</Box>
-							</Link>
-						</Clickable>
-					))}
-				</Box>
-			)
-		}
-
-		// 1 & 2 — airy transparent rows (1 shows the date, 2 titles only)
-		const withDate = variant === 1
+		// airy transparent rows — 1 titles only, 2 + date, 3 + date + chevron
+		const withDate = variant !== 1
+		const withChevron = variant === 3
 		return (
 			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
 				{last.slice(0, 5).map((s) => (
@@ -192,6 +164,7 @@ function DemoMobilePage() {
 										{dateOf(s.publishedAt)}
 									</Typography>
 								)}
+								{withChevron && <ChevronRightRounded sx={{ color: 'grey.400' }} />}
 							</Box>
 						</Link>
 					</Clickable>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -46,14 +46,14 @@ type DemoVariant = 1 | 2 | 3 | 4
  * Grey canvas + white cards for the picks; the recent section is the quiet
  * airy list (subtle M1 look). The SEARCH is buttonless with a primary
  * gradient border (desktop MainSearchInput look). The top of the page is a
- * WHITE region that reaches down INTO the (intact) picks section, softened so
- * it doesn't cut the section with a hard line — WITHOUT a background gradient.
- * Variants use different non-gradient softening techniques:
+ * soft WHITE → grey wash that reaches down INTO the (intact) picks section and
+ * fades out behind the cards — no hard line dividing the section. Variants
+ * tune how deep the white reaches and how gentle the fade is:
  *
- * 1 — blurred white panel, edge feathers behind the first card (default)
- * 2 — blurred white panel, deeper — feathers behind the second card
- * 3 — solid white sheet with rounded bottom + soft shadow (sheet look)
- * 4 — solid white block, straight edge hidden behind the first card
+ * 1 — fades out behind the first card
+ * 2 — reaches deeper, fades behind the second card
+ * 3 — shorter, whiter — ends higher, just into the first card
+ * 4 — very soft, long wash over the whole top (default)
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -72,7 +72,7 @@ function DemoMobilePage() {
 	const navigate = useSmartNavigate()
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	const variant: DemoVariant = parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 1
+	const variant: DemoVariant = parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 4
 
 	const submit = () => query.trim() && navigate('home', { hledat: query.trim() })
 
@@ -222,39 +222,15 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// ---- white top reaching into the picks section — no gradient -----
+	// ---- white → grey wash: reaches into the picks section, no hard line
 
-	// non-gradient ways to soften where the white meets the grey canvas:
-	//   blur  = a blurred white panel whose bottom edge feathers into grey
-	//   sheet = a solid white sheet with rounded bottom + soft shadow
-	//   solid = a solid white block whose straight edge hides behind a card
-	const bgMode: 'blur' | 'sheet' | 'solid' = variant === 3 ? 'sheet' : variant === 4 ? 'solid' : 'blur'
-	const bgHeight = variant === 2 ? 360 : variant === 4 ? 185 : variant === 3 ? 300 : 260
-	const BG_BLEED = 48 // pushes the blurred panel's top/side feather off-screen
-
-	const backgroundLayer = (
-		<Box
-			sx={{
-				position: 'absolute',
-				top: bgMode === 'blur' ? `-${BG_BLEED}px` : 0,
-				left: bgMode === 'blur' ? `-${BG_BLEED}px` : 0,
-				right: bgMode === 'blur' ? `-${BG_BLEED}px` : 0,
-				height:
-					bgMode === 'blur'
-						? `calc(env(safe-area-inset-top) + ${bgHeight}px + ${BG_BLEED}px)`
-						: `calc(env(safe-area-inset-top) + ${bgHeight}px)`,
-				bgcolor: 'background.paper',
-				...(bgMode === 'blur' && { filter: 'blur(22px)' }),
-				...(bgMode === 'sheet' && {
-					borderBottomLeftRadius: 4,
-					borderBottomRightRadius: 4,
-					boxShadow: '0 8px 20px rgba(0,0,0,0.07)',
-				}),
-				zIndex: 0,
-				pointerEvents: 'none',
-			}}
-		/>
-	)
+	const heroWhite = theme.palette.common.white
+	const heroGrey = theme.palette.grey[100]
+	// how deep the white reaches (px) + where the fade begins/ends (%)
+	const bgHeight = variant === 2 ? 360 : variant === 3 ? 220 : variant === 4 ? 400 : 280
+	const solidStop = variant === 4 ? 25 : variant === 3 ? 55 : variant === 2 ? 45 : 50
+	const greyStop = variant === 3 ? 92 : variant === 4 ? 100 : variant === 2 ? 85 : 80
+	const heroBg = `linear-gradient(to bottom, ${heroWhite} 0%, ${heroWhite} ${solidStop}%, ${heroGrey} ${greyStop}%)`
 
 	return (
 		<Box
@@ -280,11 +256,21 @@ function DemoMobilePage() {
 					flexDirection: 'column',
 					boxShadow: 3,
 					position: 'relative',
-					overflow: 'hidden', // clip the blurred panel's off-screen bleed
 				}}
 			>
-				{/* white top behind the header + into the picks section (no gradient) */}
-				{backgroundLayer}
+				{/* white → grey wash behind the top; fades out inside the picks section */}
+				<Box
+					sx={{
+						position: 'absolute',
+						top: 0,
+						left: 0,
+						right: 0,
+						height: `calc(env(safe-area-inset-top) + ${bgHeight}px)`,
+						background: heroBg,
+						zIndex: 0,
+						pointerEvents: 'none',
+					}}
+				/>
 				<Box sx={{ position: 'relative', zIndex: 1 }}>
 					{header}
 					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2, paddingBottom: CONTENT_CLEARANCE }}>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -28,7 +28,7 @@ import {
 } from '@mui/icons-material'
 import { Sheet } from '@pepavlin/sheet-api'
 import { useTranslations } from 'next-intl'
-import { ReactNode, useState } from 'react'
+import { Fragment, ReactNode, useState } from 'react'
 import { BasicVariantPack } from '../../../api/dtos'
 
 export default SmartPage(DemoMobilePage, [
@@ -47,14 +47,15 @@ const DOCKED_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 type DemoVariant = 1 | 2 | 3 | 4 | 5
 
 /**
- * Five structurally different landing concepts (not recolors), all inside
- * the same native shell (bottom tab bar):
+ * Five native list/chat/index landings, all built ONLY from real data
+ * (recommended songs, recently added, search, browse-all) — no invented
+ * curation features. All share the bottom tab-bar shell.
  *
- * 1 — shelves: Spotify-style greeting + horizontal shelves of square art
- * 2 — grid: colorful mood-tile grid (big rounded cards)
- * 3 — editorial: a "song of the day" hero + compact idea list
- * 4 — chat: conversational assistant with suggestion chips + compose bar
- * 5 — index: utilitarian sticky-search list, dense and fast
+ * 1 — rich rows: two-line library rows with cover thumbnails, docked search
+ * 2 — chat chips: assistant greeting + tappable song suggestion chips
+ * 3 — chat list: assistant greeting + a song list inside a wide bubble
+ * 4 — dense index: text-only sectioned list, sticky search on top
+ * 5 — compact index: one-line thumbnail rows in sections, docked search
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -166,14 +167,25 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const greeting = (
-		<Box>
-			<Typography small color="grey.700">
-				{tHome('hero.lead')}
-			</Typography>
-			<Typography variant="h3" strong={800}>
-				{tHome('hero.title')}
-			</Typography>
+	const header = (
+		<Box
+			sx={{
+				paddingX: 2.5,
+				paddingTop: 3,
+				display: 'flex',
+				justifyContent: 'space-between',
+				alignItems: 'end',
+			}}
+		>
+			<Box>
+				<Typography small color="grey.700">
+					{tHome('hero.lead')}
+				</Typography>
+				<Typography variant="h3" strong={800}>
+					{tHome('hero.title')}
+				</Typography>
+			</Box>
+			{loginCircle}
 		</Box>
 	)
 
@@ -204,233 +216,157 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	// ---- variant 1: Spotify-style shelves ----------------------------
+	const thumb = (i: number, size = 44) => (
+		<Box
+			sx={{
+				width: size,
+				height: size,
+				borderRadius: 2,
+				background: artFor(i),
+				color: 'common.white',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				flexShrink: 0,
+			}}
+		>
+			<MusicNoteRounded fontSize="small" />
+		</Box>
+	)
 
-	const shelfTile = (s: BasicVariantPack, i: number) => (
-		<Clickable key={s.packGuid}>
+	// one song row; subtitle optional, thumbnail optional
+	const songRow = (
+		s: BasicVariantPack,
+		i: number,
+		opts: { subtitle?: string; trailing?: ReactNode; showThumb?: boolean } = {}
+	) => (
+		<Clickable>
 			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-				<Box sx={{ width: 132, display: 'flex', flexDirection: 'column', gap: 1 }}>
-					<Box
-						sx={{
-							width: 132,
-							height: 132,
-							borderRadius: 3,
-							background: artFor(i),
-							color: 'common.white',
-							display: 'flex',
-							alignItems: 'flex-end',
-							padding: 1.25,
-							boxShadow: 1,
-						}}
-					>
-						<MusicNoteRounded />
+				<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25 }}>
+					{opts.showThumb && thumb(i)}
+					<Box sx={{ minWidth: 0, flex: 1 }}>
+						<Typography strong noWrap>
+							{s.title}
+						</Typography>
+						{opts.subtitle && (
+							<Typography small color="grey.700" noWrap>
+								{opts.subtitle}
+							</Typography>
+						)}
 					</Box>
-					<Typography strong noWrap sx={{ paddingX: 0.5 }}>
-						{s.title}
-					</Typography>
+					{opts.trailing}
+					<ChevronRightRounded sx={{ color: 'grey.400' }} />
 				</Box>
 			</Link>
 		</Clickable>
 	)
 
-	const shelf = (title: string, songs: BasicVariantPack[], offset = 0) => (
-		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-			<Box sx={{ paddingX: 2.5 }}>{label(title, browseAction)}</Box>
-			<Box
-				sx={{
-					display: 'flex',
-					gap: 1.5,
-					overflowX: 'auto',
-					paddingX: 2.5,
-					paddingBottom: 0.5,
-					scrollSnapType: 'x mandatory',
-					'&::-webkit-scrollbar': { display: 'none' },
-				}}
-			>
+	const rowSkeletons = (n: number, h: number) =>
+		Array.from({ length: n }).map((_, i) => (
+			<Skeleton
+				key={i}
+				variant="rounded"
+				sx={{ height: h, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }}
+			/>
+		))
+
+	// a labelled list of song rows (dividers between)
+	const listSection = (
+		title: string,
+		songs: BasicVariantPack[],
+		opts: {
+			action?: ReactNode
+			offset?: number
+			showThumb?: boolean
+			subtitle?: (s: BasicVariantPack) => string
+			trailing?: (s: BasicVariantPack) => ReactNode
+			skeletonHeight?: number
+			count?: number
+		} = {}
+	) => (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+			{label(title, opts.action)}
+			<Box sx={{ display: 'flex', flexDirection: 'column' }}>
 				{loading
-					? Array.from({ length: 4 }).map((_, i) => (
-							<Skeleton
-								key={i}
-								variant="rounded"
-								sx={{ minWidth: 132, height: 164, borderRadius: 3, bgcolor: 'grey.200' }}
-							/>
-					  ))
-					: songs.slice(0, 8).map((s, i) => shelfTile(s, i + offset))}
+					? rowSkeletons(opts.count ?? 4, opts.skeletonHeight ?? 56)
+					: songs.slice(0, opts.count ?? 5).map((s, i, arr) => (
+							<Fragment key={s.packGuid}>
+								{songRow(s, i + (opts.offset ?? 0), {
+									showThumb: opts.showThumb,
+									subtitle: opts.subtitle?.(s),
+									trailing: opts.trailing?.(s),
+								})}
+								{i < arr.length - 1 && <Divider />}
+							</Fragment>
+					  ))}
 			</Box>
 		</Box>
 	)
 
-	const shelvesVariant = (
+	const dateChip = (s: BasicVariantPack) =>
+		s.publishedAt ? (
+			<Typography small color="grey.500" noWrap>
+				{getSmartDateAgoString(s.publishedAt)}
+			</Typography>
+		) : null
+
+	// ---- variant 1: rich two-line rows -------------------------------
+
+	const richVariant = (
 		<>
-			<Box sx={{ paddingX: 2.5, paddingTop: 3, paddingBottom: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
-				<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
-					{greeting}
-					{loginCircle}
-				</Box>
-				{searchPill}
-			</Box>
-			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingBottom: TAB_CLEARANCE }}>
-				{shelf(tHome('recommended.idea'), rec)}
-				{shelf(tHome('lastAdded.title'), last, 2)}
-			</Box>
-		</>
-	)
-
-	// ---- variant 2: colorful mood grid -------------------------------
-
-	const gridTile = (s: BasicVariantPack, i: number) => (
-		<Clickable key={s.packGuid}>
-			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-				<Box
-					sx={{
-						height: 150,
-						borderRadius: 3,
-						background: artFor(i),
-						color: 'common.white',
-						padding: 1.75,
-						display: 'flex',
-						flexDirection: 'column',
-						justifyContent: 'space-between',
-						boxShadow: 1,
-					}}
-				>
-					<Box
-						sx={{
-							width: 34,
-							height: 34,
-							borderRadius: 2,
-							bgcolor: alpha(theme.palette.common.white, 0.25),
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-						}}
-					>
-						<MusicNoteRounded fontSize="small" />
-					</Box>
-					<Typography strong>{s.title}</Typography>
-				</Box>
-			</Link>
-		</Clickable>
-	)
-
-	const gridVariant = (
-		<>
-			<Box sx={{ paddingX: 2.5, paddingTop: 3, paddingBottom: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
-				<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
-					{greeting}
-					{loginCircle}
-				</Box>
-				{searchPill}
-			</Box>
-			<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5, paddingBottom: TAB_CLEARANCE }}>
-				{label(tHome('recommended.idea'))}
-				<Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5 }}>
-					{loading
-						? Array.from({ length: 6 }).map((_, i) => (
-								<Skeleton key={i} variant="rounded" sx={{ height: 150, borderRadius: 3, bgcolor: 'grey.200' }} />
-						  ))
-						: rec.slice(0, 6).map((s, i) => gridTile(s, i))}
-				</Box>
-			</Box>
-		</>
-	)
-
-	// ---- variant 3: editorial "song of the day" ----------------------
-
-	const feature = rec[0]
-	const editorialVariant = (
-		<>
-			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
-				{greeting}
-				{loginCircle}
-			</Box>
+			{header}
 			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: DOCKED_CLEARANCE }}>
-				<Box sx={{ paddingX: 2.5 }}>
-					{loading || !feature ? (
-						<Skeleton variant="rounded" sx={{ height: 220, borderRadius: 4, bgcolor: 'grey.200' }} />
-					) : (
-						<Clickable>
-							<Link to="variant" params={parseVariantAlias(feature.packAlias)}>
-								<Box
-									sx={{
-										height: 220,
-										borderRadius: 4,
-										background: gradient,
-										color: 'common.white',
-										padding: 3,
-										display: 'flex',
-										flexDirection: 'column',
-										justifyContent: 'space-between',
-										boxShadow: 3,
-									}}
-								>
-									<Typography small strong uppercase sx={{ opacity: 0.85 }}>
-										{tDemo('songOfDay')}
-									</Typography>
-									<Box>
-										<Typography variant="h4" strong={800}>
-											{feature.title}
-										</Typography>
-										<Typography sx={{ opacity: 0.9 }} noWrap>
-											{firstLine(feature.sheetData)}
-										</Typography>
-									</Box>
-								</Box>
-							</Link>
-						</Clickable>
-					)}
-				</Box>
-
-				<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
-					{label(tDemo('moreIdeas'), browseAction)}
-					<Box sx={{ display: 'flex', flexDirection: 'column' }}>
-						{loading
-							? Array.from({ length: 4 }).map((_, i) => (
-									<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
-							  ))
-							: rec.slice(1, 6).map((s, i, arr) => (
-									<Box key={s.packGuid}>
-										<Clickable>
-											<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-												<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25 }}>
-													<Box
-														sx={{
-															width: 44,
-															height: 44,
-															borderRadius: 2,
-															background: artFor(i + 1),
-															color: 'common.white',
-															display: 'flex',
-															alignItems: 'center',
-															justifyContent: 'center',
-															flexShrink: 0,
-														}}
-													>
-														<MusicNoteRounded fontSize="small" />
-													</Box>
-													<Box sx={{ minWidth: 0, flex: 1 }}>
-														<Typography strong noWrap>
-															{s.title}
-														</Typography>
-														<Typography small color="grey.700" noWrap>
-															{firstLine(s.sheetData)}
-														</Typography>
-													</Box>
-													<ChevronRightRounded sx={{ color: 'grey.500' }} />
-												</Box>
-											</Link>
-										</Clickable>
-										{i < arr.length - 1 && <Divider />}
-									</Box>
-							  ))}
-					</Box>
-				</Box>
+				{listSection(tHome('recommended.idea'), rec, {
+					action: browseAction,
+					showThumb: true,
+					subtitle: (s) => firstLine(s.sheetData),
+				})}
+				{listSection(tHome('lastAdded.title'), last, {
+					offset: 2,
+					showThumb: true,
+					subtitle: (s) => firstLine(s.sheetData),
+				})}
 			</Box>
 			<DockedSearch>{searchPill}</DockedSearch>
 		</>
 	)
 
-	// ---- variant 4: chat assistant -----------------------------------
+	// ---- variant 2 & 3: chat -----------------------------------------
+
+	const bubble = (children: ReactNode) => (
+		<Box
+			sx={{
+				alignSelf: 'flex-start',
+				maxWidth: '88%',
+				bgcolor: 'grey.100',
+				borderRadius: '4px 18px 18px 18px',
+				paddingX: 2,
+				paddingY: 1.25,
+			}}
+		>
+			{children}
+		</Box>
+	)
+
+	const assistantRow = (children: ReactNode) => (
+		<Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
+			<Box
+				sx={{
+					width: 36,
+					height: 36,
+					borderRadius: 10,
+					bgcolor: 'grey.100',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					flexShrink: 0,
+				}}
+			>
+				<Image src={getAssetUrl('/sheeps/ovce3.svg')} alt="" width={26} height={26} />
+			</Box>
+			{children}
+		</Box>
+	)
 
 	const chatChip = (s: BasicVariantPack) => (
 		<Clickable key={s.packGuid}>
@@ -453,46 +389,54 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const bubble = (children: ReactNode) => (
-		<Box
-			sx={{
-				alignSelf: 'flex-start',
-				maxWidth: '85%',
-				bgcolor: 'grey.100',
-				borderRadius: '4px 18px 18px 18px',
-				paddingX: 2,
-				paddingY: 1.25,
-			}}
-		>
-			{children}
-		</Box>
+	const composeBar = (
+		<DockedSearch>
+			<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+				<Box
+					sx={{
+						flex: 1,
+						display: 'flex',
+						alignItems: 'center',
+						gap: 1,
+						bgcolor: 'background.paper',
+						border: '1px solid',
+						borderColor: 'grey.300',
+						borderRadius: 10,
+						paddingX: 2,
+						paddingY: 1.5,
+						boxShadow: 2,
+					}}
+				>
+					{searchField}
+				</Box>
+				<Box
+					role="button"
+					aria-label={tSearch('searchByTitleOrText')}
+					onClick={() => query.trim() && navigate('home', { hledat: query.trim() })}
+					sx={{
+						width: 48,
+						height: 48,
+						borderRadius: 10,
+						background: gradient,
+						color: 'common.white',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						flexShrink: 0,
+						boxShadow: 3,
+					}}
+				>
+					<ArrowForwardRounded />
+				</Box>
+			</Box>
+		</DockedSearch>
 	)
 
-	const chatVariant = (
+	const chatChipsVariant = (
 		<>
-			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
-				{greeting}
-				{loginCircle}
-			</Box>
+			{header}
 			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', flexDirection: 'column', gap: 2, paddingBottom: DOCKED_CLEARANCE }}>
-				<Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
-					<Box
-						sx={{
-							width: 36,
-							height: 36,
-							borderRadius: 10,
-							bgcolor: 'grey.100',
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-							flexShrink: 0,
-						}}
-					>
-						<Image src={getAssetUrl('/sheeps/ovce3.svg')} alt="" width={26} height={26} />
-					</Box>
-					{bubble(<Typography>{tDemo('assistantGreeting')}</Typography>)}
-				</Box>
-
+				{assistantRow(bubble(<Typography>{tDemo('assistantGreeting')}</Typography>))}
 				{bubble(
 					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
 						<Typography small color="grey.700">
@@ -507,7 +451,6 @@ function DemoMobilePage() {
 						</Box>
 					</Box>
 				)}
-
 				{bubble(
 					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
 						<Typography small color="grey.700">
@@ -519,66 +462,56 @@ function DemoMobilePage() {
 					</Box>
 				)}
 			</Box>
-
-			<DockedSearch>
-				<Box
-					component="form"
-					onSubmit={submitSearch}
-					sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-				>
-					<Box
-						sx={{
-							flex: 1,
-							display: 'flex',
-							alignItems: 'center',
-							gap: 1,
-							bgcolor: 'background.paper',
-							border: '1px solid',
-							borderColor: 'grey.300',
-							borderRadius: 10,
-							paddingX: 2,
-							paddingY: 1.5,
-							boxShadow: 2,
-						}}
-					>
-						{searchField}
-					</Box>
-					<Box
-						role="button"
-						aria-label={tSearch('searchByTitleOrText')}
-						onClick={() => query.trim() && navigate('home', { hledat: query.trim() })}
-						sx={{
-							width: 48,
-							height: 48,
-							borderRadius: 10,
-							background: gradient,
-							color: 'common.white',
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-							flexShrink: 0,
-							boxShadow: 3,
-						}}
-					>
-						<ArrowForwardRounded />
-					</Box>
-				</Box>
-			</DockedSearch>
+			{composeBar}
 		</>
 	)
 
-	// ---- variant 5: utilitarian index --------------------------------
+	const chatListVariant = (
+		<>
+			{header}
+			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', flexDirection: 'column', gap: 2, paddingBottom: DOCKED_CLEARANCE }}>
+				{assistantRow(bubble(<Typography>{tDemo('assistantGreeting')}</Typography>))}
+				<Box
+					sx={{
+						alignSelf: 'flex-start',
+						width: '92%',
+						bgcolor: 'grey.100',
+						borderRadius: '4px 18px 18px 18px',
+						padding: 1,
+					}}
+				>
+					<Typography small color="grey.700" sx={{ paddingX: 1.5, paddingTop: 0.5 }}>
+						{tDemo('tryChips')}
+					</Typography>
+					<Box sx={{ display: 'flex', flexDirection: 'column' }}>
+						{loading
+							? rowSkeletons(4, 48)
+							: rec.slice(0, 4).map((s, i, arr) => (
+									<Fragment key={s.packGuid}>
+										<Clickable>
+											<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+												<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, padding: 1.5 }}>
+													{thumb(i, 40)}
+													<Typography strong noWrap sx={{ flex: 1 }}>
+														{s.title}
+													</Typography>
+													<ChevronRightRounded sx={{ color: 'grey.400' }} />
+												</Box>
+											</Link>
+										</Clickable>
+										{i < arr.length - 1 && <Divider sx={{ marginX: 1.5 }} />}
+									</Fragment>
+							  ))}
+					</Box>
+				</Box>
+			</Box>
+			{composeBar}
+		</>
+	)
 
-	const indexList = (() => {
-		const seen = new Set<string>()
-		return [...rec, ...last].filter((s) => {
-			if (seen.has(s.packGuid)) return false
-			seen.add(s.packGuid)
-			return true
-		})
-	})()
+	// ---- variant 4: dense text index, sticky search ------------------
 
-	const indexVariant = (
+	const stickyDenseVariant = (
 		<>
 			<Box
 				sx={{
@@ -597,7 +530,14 @@ function DemoMobilePage() {
 				}}
 			>
 				<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
-					{greeting}
+					<Box>
+						<Typography small color="grey.700">
+							{tHome('hero.lead')}
+						</Typography>
+						<Typography variant="h3" strong={800}>
+							{tHome('hero.title')}
+						</Typography>
+					</Box>
 					{loginCircle}
 				</Box>
 				<Box
@@ -616,34 +556,43 @@ function DemoMobilePage() {
 					{searchField}
 				</Box>
 			</Box>
-
-			<Box sx={{ paddingTop: 1.5, paddingBottom: TAB_CLEARANCE }}>
-				<Box sx={{ paddingX: 2.5, paddingBottom: 0.5 }}>{label(tDemo('browseAll'))}</Box>
-				{loading
-					? Array.from({ length: 8 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ height: 44, borderRadius: 1, bgcolor: 'grey.200', mx: 2.5, mb: 1 }} />
-					  ))
-					: indexList.slice(0, 14).map((s, i, arr) => (
-							<Box key={s.packGuid} sx={{ paddingX: 2.5 }}>
-								<Clickable>
-									<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25 }}>
-											<Typography strong sx={{ flex: 1 }} noWrap>
-												{s.title}
-											</Typography>
-											{s.publishedAt && (
-												<Typography small color="grey.500" noWrap>
-													{getSmartDateAgoString(s.publishedAt)}
-												</Typography>
-											)}
-											<ChevronRightRounded sx={{ color: 'grey.400' }} />
-										</Box>
-									</Link>
-								</Clickable>
-								{i < arr.length - 1 && <Divider />}
-							</Box>
-					  ))}
+			<Box sx={{ paddingTop: 2, display: 'flex', flexDirection: 'column', gap: 2.5, paddingBottom: TAB_CLEARANCE }}>
+				{listSection(tHome('recommended.idea'), rec, {
+					action: browseAction,
+					count: 5,
+					skeletonHeight: 44,
+				})}
+				{listSection(tHome('lastAdded.title'), last, {
+					offset: 2,
+					count: 5,
+					skeletonHeight: 44,
+					trailing: dateChip,
+				})}
 			</Box>
+		</>
+	)
+
+	// ---- variant 5: compact thumbnail index, docked search -----------
+
+	const compactVariant = (
+		<>
+			{header}
+			<Box sx={{ paddingTop: 2.5, display: 'flex', flexDirection: 'column', gap: 2.5, paddingBottom: DOCKED_CLEARANCE }}>
+				{listSection(tHome('recommended.idea'), rec, {
+					action: browseAction,
+					showThumb: true,
+					count: 5,
+					skeletonHeight: 48,
+				})}
+				{listSection(tHome('lastAdded.title'), last, {
+					offset: 2,
+					showThumb: true,
+					count: 5,
+					skeletonHeight: 48,
+					trailing: dateChip,
+				})}
+			</Box>
+			<DockedSearch>{searchPill}</DockedSearch>
 		</>
 	)
 
@@ -651,14 +600,14 @@ function DemoMobilePage() {
 
 	const body =
 		variant === 1
-			? shelvesVariant
+			? richVariant
 			: variant === 2
-			? gridVariant
+			? chatChipsVariant
 			: variant === 3
-			? editorialVariant
+			? chatListVariant
 			: variant === 4
-			? chatVariant
-			: indexVariant
+			? stickyDenseVariant
+			: compactVariant
 
 	return (
 		<Box

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -46,14 +46,14 @@ type DemoVariant = 1 | 2 | 3 | 4
  * Grey canvas + white cards for the picks; the recent section is the quiet
  * airy list (subtle M1 look). The SEARCH is buttonless with a primary
  * gradient border (desktop MainSearchInput look). The top of the page is a
- * soft WHITE → grey wash that reaches down INTO the (intact) picks section and
- * fades out behind the cards — no hard line dividing the section. Variants
- * tune how deep the white reaches and how gentle the fade is:
+ * WHITE region that reaches down INTO the (intact) picks section, softened so
+ * it doesn't cut the section with a hard line — WITHOUT a background gradient.
+ * Variants use different non-gradient softening techniques:
  *
- * 1 — fades out behind the first card (default)
- * 2 — reaches deeper, fades behind the second card
- * 3 — shorter, whiter — ends higher, just into the first card
- * 4 — very soft, long wash over the whole top
+ * 1 — blurred white panel, edge feathers behind the first card (default)
+ * 2 — blurred white panel, deeper — feathers behind the second card
+ * 3 — solid white sheet with rounded bottom + soft shadow (sheet look)
+ * 4 — solid white block, straight edge hidden behind the first card
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -222,15 +222,39 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// ---- white → grey wash: reaches into the picks section, no hard line
+	// ---- white top reaching into the picks section — no gradient -----
 
-	const heroWhite = theme.palette.common.white
-	const heroGrey = theme.palette.grey[100]
-	// how deep the white reaches (px) + where the fade begins/ends (%)
-	const bgHeight = variant === 2 ? 360 : variant === 3 ? 220 : variant === 4 ? 400 : 280
-	const solidStop = variant === 4 ? 25 : variant === 3 ? 55 : variant === 2 ? 45 : 50
-	const greyStop = variant === 3 ? 92 : variant === 4 ? 100 : variant === 2 ? 85 : 80
-	const heroBg = `linear-gradient(to bottom, ${heroWhite} 0%, ${heroWhite} ${solidStop}%, ${heroGrey} ${greyStop}%)`
+	// non-gradient ways to soften where the white meets the grey canvas:
+	//   blur  = a blurred white panel whose bottom edge feathers into grey
+	//   sheet = a solid white sheet with rounded bottom + soft shadow
+	//   solid = a solid white block whose straight edge hides behind a card
+	const bgMode: 'blur' | 'sheet' | 'solid' = variant === 3 ? 'sheet' : variant === 4 ? 'solid' : 'blur'
+	const bgHeight = variant === 2 ? 360 : variant === 4 ? 185 : variant === 3 ? 300 : 260
+	const BG_BLEED = 48 // pushes the blurred panel's top/side feather off-screen
+
+	const backgroundLayer = (
+		<Box
+			sx={{
+				position: 'absolute',
+				top: bgMode === 'blur' ? `-${BG_BLEED}px` : 0,
+				left: bgMode === 'blur' ? `-${BG_BLEED}px` : 0,
+				right: bgMode === 'blur' ? `-${BG_BLEED}px` : 0,
+				height:
+					bgMode === 'blur'
+						? `calc(env(safe-area-inset-top) + ${bgHeight}px + ${BG_BLEED}px)`
+						: `calc(env(safe-area-inset-top) + ${bgHeight}px)`,
+				bgcolor: 'background.paper',
+				...(bgMode === 'blur' && { filter: 'blur(22px)' }),
+				...(bgMode === 'sheet' && {
+					borderBottomLeftRadius: 4,
+					borderBottomRightRadius: 4,
+					boxShadow: '0 8px 20px rgba(0,0,0,0.07)',
+				}),
+				zIndex: 0,
+				pointerEvents: 'none',
+			}}
+		/>
+	)
 
 	return (
 		<Box
@@ -256,21 +280,11 @@ function DemoMobilePage() {
 					flexDirection: 'column',
 					boxShadow: 3,
 					position: 'relative',
+					overflow: 'hidden', // clip the blurred panel's off-screen bleed
 				}}
 			>
-				{/* white → grey wash behind the top; fades out inside the picks section */}
-				<Box
-					sx={{
-						position: 'absolute',
-						top: 0,
-						left: 0,
-						right: 0,
-						height: `calc(env(safe-area-inset-top) + ${bgHeight}px)`,
-						background: heroBg,
-						zIndex: 0,
-						pointerEvents: 'none',
-					}}
-				/>
+				{/* white top behind the header + into the picks section (no gradient) */}
+				{backgroundLayer}
 				<Box sx={{ position: 'relative', zIndex: 1 }}>
 					{header}
 					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2, paddingBottom: CONTENT_CLEARANCE }}>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import AllListPanel from '@/app/components/components/AllListPanel/AllListPanel'
 import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
 import MainSearchInput from '@/app/components/components/MainSearchInput'
-import RecommendedSongsList from '@/app/components/components/RecommendedSongsList/RecommendedSongsList'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
 import RowSongPackCard from '@/common/components/song/RowSongPackCard'
@@ -38,38 +36,47 @@ const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const TAB_BAR = 'calc(env(safe-area-inset-bottom) + 64px)'
 const CONTENT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 176px)'
 
-type DemoVariant = 1 | 2 | 3 | 4 | 5
+type DemoVariant = 1 | 2 | 3 | 4
 
 /**
- * The agreed mobile layout (greeting header, picks + recent sections,
- * docked search, tab bar) but built from the REAL desktop components so it
- * feels like the same app. Variants differ in which desktop components /
- * densities are used:
+ * The D1 layout (desktop song cards + recent pills + desktop search), made
+ * less flat purely with GREY hierarchy — no new colors. Variants tune the
+ * shades/depth so surfaces read apart:
  *
- * 1 — dense song cards (SongVariantCard dense) + recent pills, desktop search
- * 2 — full song cards (SongVariantCard) + recent pills, desktop search
- * 3 — the actual RecommendedSongsList + AllListPanel + recent pills
- * 4 — song cards for both picks and recent (uniform), grey elevated search
- * 5 — dense cards + recent pills, desktop search with the gradient border
+ * 1 — bordered: white page, white cards with a hairline border, grey pills
+ * 2 — elevated: white page, white cards lifted by a soft shadow, grey pills
+ * 3 — grouped: light-grey canvas, white cards for both sections (iOS-like)
+ * 4 — banded: white page, bordered cards, recent on a full-width grey band
  */
 function DemoMobilePage() {
 	const theme = useTheme()
 	const tHome = useTranslations('home')
 	const tNav = useTranslations('navigation')
-	const tSearch = useTranslations('search')
 
 	const [query, setQuery] = useState('')
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
-
 	const rec = recommended.data
 	const last = lastAdded.data
 	const loading = recommended.isLoading || lastAdded.isLoading
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	const variant: DemoVariant = parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 1
+	const variant: DemoVariant = parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 2
+
+	// grey palette per variant — the only thing that changes
+	const greyCanvas = variant === 3
+	const pageBg = greyCanvas ? 'grey.100' : 'background.paper'
+
+	// recent shows white cards on a grey surface in the grouped/banded looks
+	const recentWhiteCards = variant === 3 || variant === 4
+
+	// white song card that lifts off the surface via border and/or shadow
+	const cardSx =
+		variant === 1 || variant === 4
+			? { bgcolor: 'background.paper', border: '1px solid', borderColor: 'grey.200', boxShadow: 'none' as const }
+			: { bgcolor: 'background.paper', boxShadow: 1 }
 
 	// ---- header ------------------------------------------------------
 
@@ -96,7 +103,7 @@ function DemoMobilePage() {
 				<Link to="login" params={{ previousPage: '', message: '' }}>
 					<Box
 						aria-label={tNav('login')}
-						sx={{ width: 42, height: 42, borderRadius: 10, bgcolor: 'grey.100', color: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+						sx={{ width: 42, height: 42, borderRadius: 10, bgcolor: greyCanvas ? 'background.paper' : 'grey.100', color: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: greyCanvas ? 1 : 0 }}
 					>
 						<LoginRounded fontSize="small" />
 					</Box>
@@ -124,99 +131,54 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const cardSkeletons = (n: number, h: number) =>
+	const skeletons = (n: number, h: number) =>
 		Array.from({ length: n }).map((_, i) => (
-			<Skeleton key={i} variant="rounded" sx={{ height: h, borderRadius: 2, bgcolor: 'grey.200' }} />
+			<Skeleton key={i} variant="rounded" sx={{ height: h, borderRadius: 2, bgcolor: greyCanvas ? 'grey.200' : 'grey.100' }} />
 		))
 
-	// ---- picks section (desktop song cards) --------------------------
+	// ---- picks: dense white song cards -------------------------------
 
-	const picksCards = (dense: boolean) => (
+	const picks = (
 		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
 			{label(tHome('recommended.idea'), browseAction)}
 			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
 				{loading
-					? cardSkeletons(4, dense ? 56 : 120)
-					: rec.slice(0, dense ? 5 : 4).map((s) => (
-							<SongVariantCard key={s.packGuid} data={s} dense={dense} sx={{ boxShadow: 1 }} />
-					  ))}
+					? skeletons(4, 56)
+					: rec.slice(0, 5).map((s) => <SongVariantCard key={s.packGuid} data={s} dense sx={cardSx} />)}
 			</Box>
 		</Box>
 	)
 
-	// the actual desktop RecommendedSongsList component
-	const picksComponent = (
-		<Box sx={{ paddingX: 1 }}>
-			<RecommendedSongsList listType="list" dense />
-		</Box>
-	)
+	// ---- recent: grey pills (or white cards in the grouped variant) --
 
-	// ---- recent section ----------------------------------------------
-
-	// desktop RowSongPackCard pills
-	const recentPills = (
-		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-			{label(tHome('lastAdded.title'))}
-			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-				{loading ? cardSkeletons(4, 48) : last.slice(0, 5).map((s) => <RowSongPackCard key={s.packGuid} data={s} />)}
-			</Box>
-		</Box>
-	)
-
-	// desktop song cards for recent too (uniform look)
-	const recentCards = (
-		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-			{label(tHome('lastAdded.title'))}
-			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+	const recent = (
+		<Box
+			sx={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 1.5,
+				// banded variant puts recent on a full-width grey strip
+				...(variant === 4 && { bgcolor: 'grey.100', paddingY: 2.5 }),
+			}}
+		>
+			<Box sx={{ paddingX: 2.5 }}>{label(tHome('lastAdded.title'))}</Box>
+			<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
 				{loading
-					? cardSkeletons(4, 56)
-					: last.slice(0, 5).map((s) => (
-							<SongVariantCard key={s.packGuid} data={s} dense properties={['SHOW_PUBLISHED_DATE']} sx={{ boxShadow: 1 }} />
-					  ))}
+					? skeletons(4, 48)
+					: recentWhiteCards
+					? last.slice(0, 5).map((s) => (
+							<SongVariantCard key={s.packGuid} data={s} dense properties={['SHOW_PUBLISHED_DATE']} sx={cardSx} />
+					  ))
+					: last.slice(0, 5).map((s) => <RowSongPackCard key={s.packGuid} data={s} />)}
 			</Box>
 		</Box>
 	)
 
 	// ---- search: the real desktop MainSearchInput --------------------
 
-	const desktopSearch = (gradientBorder: boolean) => (
-		<MainSearchInput gradientBorder={gradientBorder} value={query} onChange={setQuery} autoFocus={false} />
+	const search = (
+		<MainSearchInput gradientBorder={false} value={query} onChange={setQuery} autoFocus={false} />
 	)
-
-	// ---- compose body + search per variant ---------------------------
-
-	const body =
-		variant === 1 ? (
-			<>
-				{picksCards(true)}
-				{recentPills}
-			</>
-		) : variant === 2 ? (
-			<>
-				{picksCards(false)}
-				{recentPills}
-			</>
-		) : variant === 3 ? (
-			<>
-				{picksComponent}
-				{recentPills}
-				<Box sx={{ paddingX: 2.5 }}>
-					<AllListPanel />
-				</Box>
-			</>
-		) : variant === 4 ? (
-			<>
-				{picksCards(true)}
-				{recentCards}
-			</>
-		) : (
-			<>
-				{picksCards(true)}
-				{recentPills}
-			</>
-		)
-
-	const search = desktopSearch(variant === 5)
 
 	return (
 		<Box
@@ -236,7 +198,7 @@ function DemoMobilePage() {
 					maxWidth: PAGE_MAX_WIDTH,
 					minWidth: 0,
 					minHeight: '100dvh',
-					bgcolor: 'background.paper',
+					bgcolor: pageBg,
 					display: 'flex',
 					flexDirection: 'column',
 					boxShadow: 3,
@@ -245,7 +207,8 @@ function DemoMobilePage() {
 			>
 				{header}
 				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: CONTENT_CLEARANCE }}>
-					{body}
+					{picks}
+					{recent}
 				</Box>
 
 				{/* ===== SEARCH: floating above the tab bar (thumb zone) ===== */}
@@ -284,7 +247,7 @@ function DemoMobilePage() {
 						zIndex: 10,
 					}}
 				>
-					<Link to="demoMobile" params={{ v: undefined }} style={{ flex: 1 }}>
+					<Link to="demoMobile" params={{ v }} style={{ flex: 1 }}>
 						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active />
 					</Link>
 					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -45,13 +45,14 @@ type DemoVariant = 1 | 2 | 3 | 4
 
 /**
  * Grey canvas + white cards for the picks; the recent section is the quiet
- * airy list (subtle M1 look). The SEARCH now has a blue submit button built
- * into the field so it stands out — variants tune that button:
+ * airy list (subtle M1 look). The SEARCH is a white, mostly-squared field
+ * with a short placeholder and a SMALL blue submit button so it stands out
+ * without crowding the text — variants only tune that button:
  *
- * 1 — blue square button, grey elevated field (default)
- * 2 — blue square button, white bordered field
- * 3 — blue rounded "D" cap on a pill field
- * 4 — blue button with a "HLEDAT" label
+ * 1 — small squared blue button + arrow (default, matches the angular field)
+ * 2 — small squared blue button + search icon
+ * 3 — small circular blue button + arrow
+ * 4 — sharp (barely-rounded) field + squared button
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -184,11 +185,11 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// ---- search: field with a blue submit button built in ------------
+	// ---- search: white, angular field + a SMALL blue submit button ---
 
-	const pill = variant === 3
-	const withLabel = variant === 4
-	const outlined = variant === 2
+	const roundButton = variant === 3 // 3 = circle button, others squared
+	const fieldRadius = variant === 4 ? 1 : 1.5 // 4 = sharper corners
+	const buttonIcon = variant === 2 ? <SearchRounded sx={{ fontSize: 18 }} /> : <ArrowForwardRounded sx={{ fontSize: 18 }} />
 
 	const search = (
 		<Box
@@ -199,42 +200,43 @@ function DemoMobilePage() {
 			}}
 			sx={{
 				display: 'flex',
-				alignItems: 'stretch',
-				bgcolor: outlined ? 'background.paper' : 'grey.100',
-				...(outlined && { border: '1px solid', borderColor: 'grey.300' }),
-				borderRadius: pill ? 10 : 2.5,
-				overflow: 'hidden',
+				alignItems: 'center',
+				gap: 1,
+				bgcolor: 'background.paper',
+				border: '1px solid',
+				borderColor: 'grey.200',
+				borderRadius: fieldRadius,
 				boxShadow: 2,
+				paddingLeft: 1.75,
+				paddingRight: 0.75,
+				paddingY: 0.75,
+				minWidth: 0,
 			}}
 		>
-			<Box sx={{ flex: 1, display: 'flex', alignItems: 'center', gap: 1, paddingLeft: 2, paddingY: 1.5, minWidth: 0 }}>
-				<SearchRounded sx={{ color: 'grey.600' }} />
-				<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
+			<SearchRounded sx={{ color: 'grey.500', fontSize: 20 }} />
+			<Box sx={{ flex: 1, minWidth: 0 }}>
+				<TextField value={query} onChange={setQuery} placeholder={tSearch('searchSongs')} />
 			</Box>
 			<Box
 				role="button"
-				aria-label={tSearch('searchByTitleOrText')}
+				aria-label={tSearch('searchSongs')}
 				onClick={submit}
 				sx={{
+					width: 32,
+					height: 32,
+					flexShrink: 0,
+					borderRadius: roundButton ? 10 : 1,
 					bgcolor: 'primary.main',
 					color: 'common.white',
 					display: 'flex',
 					alignItems: 'center',
 					justifyContent: 'center',
-					gap: 0.75,
-					paddingX: withLabel ? 2.25 : 2.5,
 					cursor: 'pointer',
-					flexShrink: 0,
 					transition: 'background-color 0.15s',
 					'&:hover': { bgcolor: 'primary.dark' },
 				}}
 			>
-				<ArrowForwardRounded fontSize="small" />
-				{withLabel && (
-					<Typography small strong uppercase color="common.white">
-						{tNav('search')}
-					</Typography>
-				)}
+				{buttonIcon}
 			</Box>
 		</Box>
 	)

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -4,7 +4,7 @@ import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/ho
 import MainSearchInput from '@/app/components/components/MainSearchInput'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
-import { Box, Clickable, Divider, Typography, useTheme } from '@/common/ui'
+import { Box, Clickable, Typography, useTheme } from '@/common/ui'
 import { alpha } from '@/common/ui/mui'
 import { Link } from '@/common/ui/Link/Link'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
@@ -13,7 +13,6 @@ import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
-	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
 	LibraryMusicOutlined,
@@ -23,7 +22,7 @@ import {
 	PersonRounded,
 } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
-import { Fragment, ReactNode, useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 export default SmartPage(DemoMobilePage, [
 	'hideToolbar',
@@ -42,13 +41,13 @@ type DemoVariant = 1 | 2 | 3 | 4
 
 /**
  * Grey canvas + white cards for the picks (the liked G3 look). The recent
- * section is kept deliberately QUIET so it recedes below the picks —
- * variants only change how subtle it is:
+ * section stays QUIET; these variants refine the two liked directions —
+ * the airy list and the chips:
  *
- * 1 — quiet rows: transparent rows with hairline dividers
- * 2 — airy list: spaced rows, muted, no dividers or chevrons
- * 3 — chips: small bordered title chips that wrap
- * 4 — flat cards: white cards but flat (no lift) so they sit quietly
+ * 1 — airy list with date: spaced muted rows, title + date
+ * 2 — airy list, titles only: even cleaner, no dates
+ * 3 — chips outlined: small bordered title chips that wrap
+ * 4 — chips filled: soft grey filled chips, no border
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -148,14 +147,24 @@ function DemoMobilePage() {
 			))
 		}
 
-		// 3 — subtle bordered title chips
-		if (variant === 3) {
+		// 3 & 4 — title chips (3 outlined, 4 soft filled)
+		if (variant === 3 || variant === 4) {
+			const filled = variant === 4
 			return (
 				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
 					{last.slice(0, 6).map((s) => (
 						<Clickable key={s.packGuid}>
 							<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-								<Box sx={{ border: '1px solid', borderColor: 'grey.300', borderRadius: 10, paddingX: 1.75, paddingY: 0.75 }}>
+								<Box
+									sx={{
+										borderRadius: 10,
+										paddingX: 1.75,
+										paddingY: 0.75,
+										...(filled
+											? { bgcolor: 'grey.200' }
+											: { border: '1px solid', borderColor: 'grey.300' }),
+									}}
+								>
 									<Typography small color="grey.700" noWrap>
 										{s.title}
 									</Typography>
@@ -167,38 +176,25 @@ function DemoMobilePage() {
 			)
 		}
 
-		// 4 — flat white cards (no lift) so they sit quietly under the picks
-		if (variant === 4) {
-			return (
-				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-					{last.slice(0, 5).map((s) => (
-						<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper' }} />
-					))}
-				</Box>
-			)
-		}
-
-		// 1 & 2 — quiet transparent rows (1 with dividers, 2 airy)
-		const airy = variant === 2
+		// 1 & 2 — airy transparent rows (1 shows the date, 2 titles only)
+		const withDate = variant === 1
 		return (
-			<Box sx={{ display: 'flex', flexDirection: 'column', gap: airy ? 0.5 : 0 }}>
-				{last.slice(0, 5).map((s, i, arr) => (
-					<Fragment key={s.packGuid}>
-						<Clickable>
-							<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-								<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: airy ? 1 : 1.25 }}>
-									<Typography color="grey.800" noWrap sx={{ flex: 1 }}>
-										{s.title}
-									</Typography>
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+				{last.slice(0, 5).map((s) => (
+					<Clickable key={s.packGuid}>
+						<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+							<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1 }}>
+								<Typography color="grey.800" noWrap sx={{ flex: 1 }}>
+									{s.title}
+								</Typography>
+								{withDate && (
 									<Typography small color="grey.500" noWrap>
 										{dateOf(s.publishedAt)}
 									</Typography>
-									{!airy && <ChevronRightRounded sx={{ color: 'grey.400' }} />}
-								</Box>
-							</Link>
-						</Clickable>
-						{!airy && i < arr.length - 1 && <Divider />}
-					</Fragment>
+								)}
+							</Box>
+						</Link>
+					</Clickable>
 				))}
 			</Box>
 		)

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -5,10 +5,8 @@ import useRecommendedSongs from '@/app/components/components/RecommendedSongsLis
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
 import {
 	Box,
-	Button,
 	Clickable,
 	Divider,
-	Image,
 	Typography,
 	useTheme,
 } from '@/common/ui'
@@ -20,10 +18,8 @@ import { TextField } from '@/common/ui/TextField'
 import { useSmartNavigate } from '@/routes/useSmartNavigate'
 import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
-import { getAssetUrl } from '@/tech/paths.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
-	AutoAwesomeRounded,
 	HomeOutlined,
 	HomeRounded,
 	LibraryMusicOutlined,
@@ -32,8 +28,6 @@ import {
 	MusicNoteRounded,
 	PersonOutlineRounded,
 	PersonRounded,
-	QueueMusicRounded,
-	ScheduleRounded,
 	SearchRounded,
 } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
@@ -50,63 +44,42 @@ export default SmartPage(DemoMobilePage, [
 
 const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
-const TAB_BAR_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
 const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
-type DemoVariant = 1 | 2 | 3 | 4 | 5
+type DemoVariant = 1 | 2 | 3
 
 /**
- * Variants — all share the "cards" language, they differ in where the
- * search lives and in the accent system:
+ * One base design (docked search in the thumb zone, iOS grouped sections,
+ * translucent tab bar, no CTA card) with three header treatments:
  *
- * 1 — search top (baseline): grey canvas, white section cards, gradient
- *     border makes the search the strongest element
- * 2 — search docked at the very bottom above the tab bar (thumb zone),
- *     otherwise identical to 1
- * 3 — search mid-screen: hero fills the upper half, trimmed content
- *     below (no last-added), otherwise the style of 1
- * 4 — polished blue system: white canvas, neutral grey panels, blue used
- *     only as accent (badges, actions, button, tab pill); search docked
- *     bottom with a solid blue border
- * 5 — Google-style minimal: an almost empty white page with just the
- *     brand, the search and one quiet action in the middle
+ * 1 — gradient header: brand gradient band with rounded bottom, white text
+ * 2 — tonal header: soft primary tint band, dark text
+ * 3 — sheet split: white header, content rides on a grey rounded sheet
  */
 function DemoMobilePage() {
 	const theme = useTheme()
 	const tHome = useTranslations('home')
 	const tNav = useTranslations('navigation')
 	const tSearch = useTranslations('search')
-	const tSuggestions = useTranslations('suggestions')
 
 	const navigate = useSmartNavigate()
 	const [query, setQuery] = useState('')
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	// docked search (2) won the design review — it is the default
 	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 2
+		parsed >= 1 && parsed <= 3 ? (parsed as DemoVariant) : 1
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
 
 	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
 
-	const blueSystem = variant === 4
-	const googleMinimal = variant === 5
-	const searchDocked = variant === 2 || variant === 4
-	const searchCentered = variant === 3
-	const showLastAdded = !searchCentered && !googleMinimal
+	const gradientHeader = variant === 1
+	const tonalHeader = variant === 2
+	const sheetSplit = variant === 3
 
-	// One card language per variant: v1–v3 white cards on grey canvas,
-	// v4 neutral grey panels on white canvas with blue accents only
-	const canvasBg =
-		blueSystem || googleMinimal ? 'background.paper' : 'grey.100'
-	const panelBg = blueSystem ? 'grey.100' : 'background.paper'
-	const panelShadow = blueSystem ? 0 : 1
-	const rowsHaveDividers = !blueSystem
-	const rowBg = blueSystem ? 'background.paper' : 'transparent'
-	const tileBg = blueSystem ? 'background.paper' : 'grey.100'
+	const canvasBg = sheetSplit ? 'background.paper' : 'grey.100'
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
@@ -115,41 +88,8 @@ function DemoMobilePage() {
 		}
 	}
 
-	const searchInner = (
-		<>
-			<SearchRounded
-				sx={{ color: blueSystem ? 'primary.main' : 'grey.600' }}
-			/>
-			<TextField
-				value={query}
-				onChange={setQuery}
-				placeholder={tSearch('searchByTitleOrText')}
-			/>
-		</>
-	)
-
-	// v1–v3: gradient border + shadow make the search the strongest element
-	// v4: solid blue border keeps the single-accent system
-	const searchForm = blueSystem ? (
-		<Box
-			component="form"
-			onSubmit={submitSearch}
-			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				gap: 1,
-				bgcolor: 'background.paper',
-				border: '2px solid',
-				borderColor: 'primary.main',
-				borderRadius: 10,
-				paddingX: 2,
-				paddingY: 1.5,
-				boxShadow: 3,
-			}}
-		>
-			{searchInner}
-		</Box>
-	) : (
+	// gradient border + shadow keep the search the strongest element
+	const searchForm = (
 		<Box
 			sx={{
 				background: gradient,
@@ -171,13 +111,18 @@ function DemoMobilePage() {
 					paddingY: 1.5,
 				}}
 			>
-				{searchInner}
+				<SearchRounded sx={{ color: 'grey.600' }} />
+				<TextField
+					value={query}
+					onChange={setQuery}
+					placeholder={tSearch('searchByTitleOrText')}
+				/>
 			</Box>
 		</Box>
 	)
 
 	// circular icon button reads more native than an uppercase text link
-	const loginLink = (
+	const loginButton = (
 		<Clickable tooltip={tNav('login')}>
 			<Link to="login" params={{ previousPage: '', message: '' }}>
 				<Box
@@ -186,9 +131,11 @@ function DemoMobilePage() {
 						width: 42,
 						height: 42,
 						borderRadius: 10,
-						bgcolor: blueSystem || googleMinimal ? 'grey.100' : 'background.paper',
-						boxShadow: blueSystem || googleMinimal ? 0 : 1,
-						color: 'primary.main',
+						bgcolor: gradientHeader
+							? alpha(theme.palette.common.white, 0.22)
+							: 'background.paper',
+						boxShadow: gradientHeader ? 0 : 1,
+						color: gradientHeader ? 'common.white' : 'primary.main',
 						display: 'flex',
 						alignItems: 'center',
 						justifyContent: 'center',
@@ -200,32 +147,18 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const sheep = (size: number) => (
-		<Image
-			src={getAssetUrl('/sheeps/ovce3.svg')}
-			alt={tSuggestions('sheep')}
-			width={size}
-			height={size}
-		/>
-	)
-
-	const headerRow = (
-		<Box
-			sx={{
-				display: 'flex',
-				justifyContent: 'space-between',
-				alignItems: 'end',
-			}}
-		>
-			<Box>
-				<Typography small color="grey.700">
-					{tHome('hero.lead')}
-				</Typography>
-				<Typography variant="h3" strong={800}>
-					{tHome('hero.title')}
-				</Typography>
-			</Box>
-			{loginLink}
+	const heroTexts = (
+		<Box>
+			<Typography
+				small
+				color={gradientHeader ? undefined : 'grey.700'}
+				sx={gradientHeader ? { opacity: 0.85 } : {}}
+			>
+				{tHome('hero.lead')}
+			</Typography>
+			<Typography variant="h3" strong={800}>
+				{tHome('hero.title')}
+			</Typography>
 		</Box>
 	)
 
@@ -239,33 +172,13 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const sectionBadge = (icon: ReactNode) => (
-		<Box
-			sx={{
-				width: 32,
-				height: 32,
-				borderRadius: 2,
-				bgcolor: alpha(theme.palette.primary.main, 0.1),
-				color: 'primary.main',
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'center',
-			}}
-		>
-			{icon}
-		</Box>
-	)
-
-	// Shared section anatomy: iOS-style grouped list — small uppercase
-	// label ABOVE the card (h6 + badge in the blue system), then the panel
+	// iOS grouped-list section: small uppercase label above a white card
 	const Section = ({
 		title,
-		icon,
 		action,
 		children,
 	}: {
 		title: string
-		icon: ReactNode
 		action?: ReactNode
 		children: ReactNode
 	}) => (
@@ -286,25 +199,16 @@ function DemoMobilePage() {
 					paddingX: 0.5,
 				}}
 			>
-				<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
-					{blueSystem && sectionBadge(icon)}
-					{blueSystem ? (
-						<Typography variant="h6" strong>
-							{title}
-						</Typography>
-					) : (
-						<Typography small strong uppercase color="grey.700">
-							{title.replace(/:$/, '')}
-						</Typography>
-					)}
-				</Box>
+				<Typography small strong uppercase color="grey.700">
+					{title.replace(/:$/, '')}
+				</Typography>
 				{action}
 			</Box>
 			<Box
 				sx={{
-					bgcolor: panelBg,
+					bgcolor: 'background.paper',
 					borderRadius: 3,
-					boxShadow: panelShadow,
+					boxShadow: 1,
 					padding: 2,
 					display: 'flex',
 					flexDirection: 'column',
@@ -322,7 +226,7 @@ function DemoMobilePage() {
 				<Box
 					sx={{
 						width: 164,
-						bgcolor: tileBg,
+						bgcolor: 'grey.100',
 						borderRadius: 2,
 						padding: 2,
 						scrollSnapAlign: 'start',
@@ -359,7 +263,7 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const listSkeletons = Array.from({ length: 4 }).map((_, i) => (
+	const listSkeletons = Array.from({ length: 5 }).map((_, i) => (
 		<Skeleton
 			key={i}
 			variant="rounded"
@@ -374,6 +278,64 @@ function DemoMobilePage() {
 			sx={{ minWidth: 164, height: 128, borderRadius: 2, bgcolor: 'grey.200' }}
 		/>
 	))
+
+	const sections = (
+		<Box
+			sx={{
+				flex: 1,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 2.5,
+				paddingTop: 2.5,
+				paddingBottom: DOCKED_SEARCH_CLEARANCE,
+			}}
+		>
+			<Section title={tHome('recommended.idea')}>
+				<Box sx={{ display: 'flex', flexDirection: 'column' }}>
+					{recommended.isLoading
+						? listSkeletons
+						: recommended.data.slice(0, 5).map((s, i, arr) => (
+								<Fragment key={s.packGuid}>
+									<SongVariantCard
+										data={s}
+										dense
+										sx={{ bgcolor: 'transparent', borderRadius: 0 }}
+									/>
+									{i < arr.length - 1 && <Divider sx={{ marginX: 1 }} />}
+								</Fragment>
+						  ))}
+				</Box>
+			</Section>
+
+			<Section title={tHome('lastAdded.title')} action={browseAction}>
+				<Box
+					sx={{
+						display: 'flex',
+						gap: 1.5,
+						overflowX: 'auto',
+						// bleed the scroll area to the panel edges, then restore
+						// the inset inside it so tiles align with the header text
+						marginX: -2,
+						paddingLeft: 2,
+						paddingY: 0.5,
+						scrollSnapType: 'x mandatory',
+						scrollPaddingLeft: theme.spacing(2),
+						'&::-webkit-scrollbar': { display: 'none' },
+						// keeps the right inset visible at the end of the scroll
+						// (trailing padding collapses in overflow containers)
+						'&::after': {
+							content: '""',
+							flex: '0 0 1px',
+						},
+					}}
+				>
+					{lastAdded.isLoading
+						? carouselSkeletons
+						: lastAdded.data.slice(0, 8).map((s) => carouselTile(s))}
+				</Box>
+			</Section>
+		</Box>
+	)
 
 	return (
 		<Box
@@ -401,302 +363,67 @@ function DemoMobilePage() {
 					boxShadow: 3,
 				}}
 			>
-				{/* ===================== HEADER (+ top/centered search) ===================== */}
-				{googleMinimal ? (
-					// Google-style: an almost empty page — brand + search in the
-					// middle, one quiet action, nothing else
+				{/* ===================== HEADER ===================== */}
+				<Box
+					sx={{
+						paddingX: 2.5,
+						paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
+						paddingBottom: gradientHeader || tonalHeader ? 3.5 : 1,
+						display: 'flex',
+						justifyContent: 'space-between',
+						alignItems: 'end',
+						...(gradientHeader && {
+							background: gradient,
+							color: 'common.white',
+							borderRadius: '0 0 28px 28px',
+						}),
+						...(tonalHeader && {
+							bgcolor: alpha(theme.palette.primary.main, 0.09),
+							borderRadius: '0 0 28px 28px',
+						}),
+					}}
+				>
+					{heroTexts}
+					{loginButton}
+				</Box>
+
+				{/* ===================== CONTENT ===================== */}
+				{sheetSplit ? (
+					// content rides on a grey rounded sheet over the white canvas
 					<Box
 						sx={{
 							flex: 1,
+							marginTop: 2,
+							bgcolor: 'grey.100',
+							borderRadius: '28px 28px 0 0',
 							display: 'flex',
 							flexDirection: 'column',
-							paddingX: 4,
-							paddingTop: 'calc(env(safe-area-inset-top) + 16px)',
-							paddingBottom: TAB_BAR_CLEARANCE,
 						}}
 					>
-						<Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-							{loginLink}
-						</Box>
-						<Box sx={{ flex: 0.85 }} />
-						<Box
-							sx={{
-								display: 'flex',
-								flexDirection: 'column',
-								alignItems: 'center',
-								gap: 3,
-							}}
-						>
-							{sheep(96)}
-							<Box sx={{ textAlign: 'center' }}>
-								<Typography small color="grey.700">
-									{tHome('hero.lead')}
-								</Typography>
-								<Typography variant="h3" strong={800}>
-									{tHome('hero.title')}
-								</Typography>
-							</Box>
-							<Box sx={{ width: '100%' }}>{searchForm}</Box>
-							<Clickable>
-								<Link to="songsList" params={{ s: undefined }}>
-									<Box
-										sx={{
-											display: 'flex',
-											alignItems: 'center',
-											gap: 1,
-											bgcolor: 'grey.100',
-											borderRadius: 10,
-											paddingX: 2.5,
-											paddingY: 1,
-										}}
-									>
-										<QueueMusicRounded
-											fontSize="small"
-											sx={{ color: 'grey.700' }}
-										/>
-										<Typography small strong>
-											{tHome('allList.title')}
-										</Typography>
-									</Box>
-								</Link>
-							</Clickable>
-						</Box>
-						<Box sx={{ flex: 1.15 }} />
-					</Box>
-				) : searchCentered ? (
-					// hero fills the upper half so the search lands mid-screen,
-					// inside comfortable thumb reach
-					<Box
-						sx={{
-							paddingX: 2.5,
-							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-							height: '52dvh',
-							display: 'flex',
-							flexDirection: 'column',
-							justifyContent: 'space-between',
-							gap: 2.5,
-						}}
-					>
-						{headerRow}
-						<Box
-							sx={{
-								flex: 1,
-								display: 'flex',
-								alignItems: 'center',
-								justifyContent: 'center',
-								pointerEvents: 'none',
-							}}
-						>
-							{sheep(120)}
-						</Box>
-						{searchForm}
+						{sections}
 					</Box>
 				) : (
-					<Box
-						sx={{
-							paddingX: 2.5,
-							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-							display: 'flex',
-							flexDirection: 'column',
-							gap: 2.5,
-						}}
-					>
-						{headerRow}
-						{!searchDocked && searchForm}
-					</Box>
-				)}
-
-				{/* ===================== SECTIONS ===================== */}
-				{!googleMinimal && (
-				<Box
-					sx={{
-						flex: 1,
-						display: 'flex',
-						flexDirection: 'column',
-						gap: 2.5,
-						paddingTop: 2.5,
-						paddingBottom: searchDocked
-							? DOCKED_SEARCH_CLEARANCE
-							: TAB_BAR_CLEARANCE,
-					}}
-				>
-					<Section
-						title={tHome('recommended.idea')}
-						icon={<AutoAwesomeRounded sx={{ fontSize: 18 }} />}
-					>
-						<Box
-							sx={{
-								display: 'flex',
-								flexDirection: 'column',
-								gap: rowsHaveDividers ? 0 : 1,
-							}}
-						>
-							{recommended.isLoading
-								? listSkeletons
-								: recommended.data
-										.slice(0, showLastAdded ? 4 : 6)
-										.map((s, i, arr) => (
-											<Fragment key={s.packGuid}>
-												<SongVariantCard
-													data={s}
-													dense
-													sx={{
-														bgcolor: rowBg,
-														borderRadius: rowsHaveDividers ? 0 : 2,
-													}}
-												/>
-												{rowsHaveDividers && i < arr.length - 1 && (
-													<Divider sx={{ marginX: 1 }} />
-												)}
-											</Fragment>
-										))}
-						</Box>
-					</Section>
-
-					{showLastAdded && (
-						<Section
-							title={tHome('lastAdded.title')}
-							icon={<ScheduleRounded sx={{ fontSize: 18 }} />}
-							action={browseAction}
-						>
-							<Box
-								sx={{
-									display: 'flex',
-									gap: 1.5,
-									overflowX: 'auto',
-									// bleed the scroll area to the panel edges, then restore
-									// the inset inside it so tiles align with the header text
-									marginX: -2,
-									paddingLeft: 2,
-									paddingY: 0.5,
-									scrollSnapType: 'x mandatory',
-									scrollPaddingLeft: theme.spacing(2),
-									'&::-webkit-scrollbar': { display: 'none' },
-									// keeps the right inset visible at the end of the scroll
-									// (trailing padding collapses in overflow containers)
-									'&::after': {
-										content: '""',
-										flex: '0 0 1px',
-									},
-								}}
-							>
-								{lastAdded.isLoading
-									? carouselSkeletons
-									: lastAdded.data.slice(0, 8).map((s) => carouselTile(s))}
-							</Box>
-						</Section>
-					)}
-
-					{/* ===================== CTA ===================== */}
-					{blueSystem ? (
-						<Box sx={{ paddingX: 2.5 }}>
-							<Box
-								sx={{
-									bgcolor: panelBg,
-									borderRadius: 3,
-									padding: 2,
-									display: 'flex',
-									flexDirection: 'column',
-									gap: 1.5,
-									position: 'relative',
-								}}
-							>
-								<Box
-									sx={{
-										position: 'absolute',
-										top: -34,
-										right: 16,
-										pointerEvents: 'none',
-									}}
-								>
-									{sheep(56)}
-								</Box>
-								<Box>
-									<Typography variant="h6" strong>
-										{tSuggestions('noIdea')}
-									</Typography>
-									<Typography small color="grey.700">
-										{tSuggestions('chooseSuggestion')}
-									</Typography>
-								</Box>
-								<Button
-									to="songsList"
-									toParams={{ s: undefined }}
-									size="large"
-									startIcon={<QueueMusicRounded />}
-								>
-									{tHome('allList.title')}
-								</Button>
-							</Box>
-						</Box>
-					) : (
-						<Box sx={{ paddingX: 2.5 }}>
-							<Box
-								sx={{
-									background: gradient,
-									color: 'common.white',
-									borderRadius: 3,
-									padding: 2.5,
-									display: 'flex',
-									flexDirection: 'column',
-									gap: 1.5,
-								}}
-							>
-								<Box>
-									<Typography variant="h6" strong>
-										{tSuggestions('noIdea')}
-									</Typography>
-									<Typography small sx={{ opacity: 0.9 }}>
-										{tSuggestions('chooseSuggestion')}
-									</Typography>
-								</Box>
-								<Clickable>
-									<Link to="songsList" params={{ s: undefined }}>
-										<Box
-											sx={{
-												bgcolor: 'background.paper',
-												color: 'primary.main',
-												borderRadius: 2,
-												paddingY: 1.5,
-												display: 'flex',
-												alignItems: 'center',
-												justifyContent: 'center',
-												gap: 1,
-											}}
-										>
-											<QueueMusicRounded fontSize="small" />
-											<Typography small strong uppercase>
-												{tHome('allList.title')}
-											</Typography>
-										</Box>
-									</Link>
-								</Clickable>
-							</Box>
-						</Box>
-					)}
-				</Box>
+					sections
 				)}
 
 				{/* ===== Docked search — floats above the tab bar (thumb zone) ===== */}
-				{searchDocked && (
-					<Box
-						sx={{
-							position: 'fixed',
-							bottom: 'calc(env(safe-area-inset-bottom) + 82px)',
-							left: '50%',
-							transform: 'translateX(-50%)',
-							width: '100%',
-							maxWidth: PAGE_MAX_WIDTH,
-							paddingX: 4,
-							// no global border-box in this app — keep the padding
-							// inside the 100% width instead of overflowing it
-							boxSizing: 'border-box',
-							zIndex: 10,
-						}}
-					>
-						{searchForm}
-					</Box>
-				)}
+				<Box
+					sx={{
+						position: 'fixed',
+						bottom: 'calc(env(safe-area-inset-bottom) + 82px)',
+						left: '50%',
+						transform: 'translateX(-50%)',
+						width: '100%',
+						maxWidth: PAGE_MAX_WIDTH,
+						paddingX: 4,
+						// no global border-box in this app — keep the padding
+						// inside the 100% width instead of overflowing it
+						boxSizing: 'border-box',
+						zIndex: 10,
+					}}
+				>
+					{searchForm}
+				</Box>
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}
 				<Box
@@ -723,7 +450,6 @@ function DemoMobilePage() {
 							activeIcon={<HomeRounded />}
 							label={tNav('home')}
 							active
-							pill={blueSystem}
 						/>
 					</Link>
 					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
@@ -731,7 +457,6 @@ function DemoMobilePage() {
 							icon={<LibraryMusicOutlined />}
 							activeIcon={<LibraryMusicRounded />}
 							label={tNav('songs')}
-							pill={blueSystem}
 						/>
 					</Link>
 					<Link to="account" params={{}} style={{ flex: 1 }}>
@@ -739,7 +464,6 @@ function DemoMobilePage() {
 							icon={<PersonOutlineRounded />}
 							activeIcon={<PersonRounded />}
 							label={tNav('account')}
-							pill={blueSystem}
 						/>
 					</Link>
 				</Box>
@@ -754,12 +478,9 @@ type TabItemProps = {
 	activeIcon?: JSX.Element
 	label: string
 	active?: boolean
-	/** Material-3-like tonal pill behind the active icon */
-	pill?: boolean
 }
 
-function TabItem({ icon, activeIcon, label, active, pill }: TabItemProps) {
-	const theme = useTheme()
+function TabItem({ icon, activeIcon, label, active }: TabItemProps) {
 	return (
 		<Box
 			sx={{
@@ -771,22 +492,7 @@ function TabItem({ icon, activeIcon, label, active, pill }: TabItemProps) {
 				color: active ? 'primary.main' : 'grey.700',
 			}}
 		>
-			<Box
-				sx={{
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-					...(pill && {
-						paddingX: 2,
-						borderRadius: 10,
-						bgcolor: active
-							? alpha(theme.palette.primary.main, 0.12)
-							: 'transparent',
-					}),
-				}}
-			>
-				{active ? activeIcon ?? icon : icon}
-			</Box>
+			{active ? activeIcon ?? icon : icon}
 			<Typography small strong={active ? 700 : 400}>
 				{label}
 			</Typography>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -47,17 +47,17 @@ const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
 type DemoVariant = 1 | 2 | 3 | 4
-type SectionStyle = 'band' | 'gap' | 'tint' | 'strip'
+type HeaderStyle = 'white' | 'lightgrey' | 'dark' | 'elevated'
 
 /**
- * One base design (square gradient header, docked search in the thumb
- * zone, translucent tab bar, no CTA card). Sections are always full-bleed
- * — four takes on separating them by background:
+ * One base design (square header, alternating full-bleed band sections,
+ * docked gradient search, translucent tab bar). The header color is the
+ * experiment — no brand blue up top, it stays in the search and accents:
  *
- * 1 — band: alternating grey/white background bands (baseline)
- * 2 — gap: white bands separated by thick grey spacer strips
- * 3 — tint: the recommended band gets a soft brand tint, the rest white
- * 4 — strip: iOS plain-table style — grey label strips over white content
+ * 1 — white: flat white header, dark text
+ * 2 — lightgrey: grey.100 header, band order flipped so surfaces alternate
+ * 3 — dark: grey.900 header with white text
+ * 4 — elevated: white header lifted with a soft shadow (classic app bar)
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -78,11 +78,16 @@ function DemoMobilePage() {
 
 	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
 
-	const sectionStyle: SectionStyle = (
-		['band', 'gap', 'tint', 'strip'] as const
+	const headerStyle: HeaderStyle = (
+		['white', 'lightgrey', 'dark', 'elevated'] as const
 	)[variant - 1]
+	const darkHeader = headerStyle === 'dark'
 
-	const canvasBg = sectionStyle === 'gap' ? 'grey.200' : 'background.paper'
+	// lightgrey header flips the band order so adjacent surfaces alternate
+	const recommendedSurface: 'white' | 'grey' =
+		headerStyle === 'lightgrey' ? 'white' : 'grey'
+	const lastAddedSurface: 'white' | 'grey' =
+		headerStyle === 'lightgrey' ? 'grey' : 'white'
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
@@ -134,8 +139,12 @@ function DemoMobilePage() {
 						width: 42,
 						height: 42,
 						borderRadius: 10,
-						bgcolor: alpha(theme.palette.common.white, 0.22),
-						color: 'common.white',
+						bgcolor: darkHeader
+							? alpha(theme.palette.common.white, 0.16)
+							: headerStyle === 'lightgrey'
+							? 'background.paper'
+							: 'grey.100',
+						color: darkHeader ? 'common.white' : 'primary.main',
 						display: 'flex',
 						alignItems: 'center',
 						justifyContent: 'center',
@@ -174,7 +183,7 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	// Section wrapper — full-bleed surfaces, the separation is the experiment
+	// full-bleed band section
 	const Section = ({
 		title,
 		action,
@@ -183,60 +192,23 @@ function DemoMobilePage() {
 	}: {
 		title: string
 		action?: ReactNode
-		/** which full-bleed background this section gets */
-		surface: 'white' | 'grey' | 'tint'
+		surface: 'white' | 'grey'
 		children: ReactNode
-	}) => {
-		const surfaceBg =
-			surface === 'grey'
-				? 'grey.100'
-				: surface === 'tint'
-				? alpha(theme.palette.primary.main, 0.06)
-				: 'background.paper'
-
-		if (sectionStyle === 'strip') {
-			return (
-				<Box>
-					<Box
-						sx={{
-							bgcolor: 'grey.100',
-							paddingY: 1,
-							paddingX: 3,
-						}}
-					>
-						{sectionLabel(title, action)}
-					</Box>
-					<Box
-						sx={{
-							paddingX: 2.5,
-							paddingY: 2,
-							display: 'flex',
-							flexDirection: 'column',
-							gap: 1.5,
-						}}
-					>
-						{children}
-					</Box>
-				</Box>
-			)
-		}
-
-		return (
-			<Box
-				sx={{
-					bgcolor: sectionStyle === 'gap' ? 'background.paper' : surfaceBg,
-					paddingY: 2.5,
-					paddingX: 2.5,
-					display: 'flex',
-					flexDirection: 'column',
-					gap: 1.5,
-				}}
-			>
-				{sectionLabel(title, action)}
-				{children}
-			</Box>
-		)
-	}
+	}) => (
+		<Box
+			sx={{
+				bgcolor: surface === 'grey' ? 'grey.100' : 'background.paper',
+				paddingY: 2.5,
+				paddingX: 2.5,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 1.5,
+			}}
+		>
+			{sectionLabel(title, action)}
+			{children}
+		</Box>
+	)
 
 	const carouselTile = (s: BasicVariantPack, bg: string) => (
 		<Clickable key={s.packGuid}>
@@ -363,7 +335,7 @@ function DemoMobilePage() {
 					maxWidth: PAGE_MAX_WIDTH,
 					minWidth: 0,
 					minHeight: '100dvh',
-					bgcolor: canvasBg,
+					bgcolor: 'background.paper',
 					display: 'flex',
 					flexDirection: 'column',
 					boxShadow: 3,
@@ -374,16 +346,34 @@ function DemoMobilePage() {
 					sx={{
 						paddingX: 2.5,
 						paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-						paddingBottom: 3.5,
+						paddingBottom: 3,
 						display: 'flex',
 						justifyContent: 'space-between',
 						alignItems: 'end',
-						background: gradient,
-						color: 'common.white',
+						...(headerStyle === 'white' && {
+							bgcolor: 'background.paper',
+						}),
+						...(headerStyle === 'lightgrey' && {
+							bgcolor: 'grey.100',
+						}),
+						...(headerStyle === 'dark' && {
+							bgcolor: 'grey.900',
+							color: 'common.white',
+						}),
+						...(headerStyle === 'elevated' && {
+							bgcolor: 'background.paper',
+							boxShadow: 2,
+							position: 'relative',
+							zIndex: 1,
+						}),
 					}}
 				>
 					<Box>
-						<Typography small sx={{ opacity: 0.85 }}>
+						<Typography
+							small
+							color={darkHeader ? undefined : 'grey.700'}
+							sx={darkHeader ? { opacity: 0.8 } : {}}
+						>
 							{tHome('hero.lead')}
 						</Typography>
 						<Typography variant="h3" strong={800}>
@@ -399,21 +389,12 @@ function DemoMobilePage() {
 						flex: 1,
 						display: 'flex',
 						flexDirection: 'column',
-						// gap style: the grey canvas shows through as spacer strips
-						gap: sectionStyle === 'gap' ? 1.5 : 0,
-						paddingTop: sectionStyle === 'gap' ? 1.5 : 0,
 						paddingBottom: DOCKED_SEARCH_CLEARANCE,
 					}}
 				>
 					<Section
 						title={tHome('recommended.idea')}
-						surface={
-							sectionStyle === 'band'
-								? 'grey'
-								: sectionStyle === 'tint'
-								? 'tint'
-								: 'white'
-						}
+						surface={recommendedSurface}
 					>
 						{recommendedRows}
 					</Section>
@@ -421,9 +402,11 @@ function DemoMobilePage() {
 					<Section
 						title={tHome('lastAdded.title')}
 						action={browseAction}
-						surface="white"
+						surface={lastAddedSurface}
 					>
-						{lastAddedCarousel('grey.100')}
+						{lastAddedCarousel(
+							lastAddedSurface === 'white' ? 'grey.100' : 'background.paper'
+						)}
 					</Section>
 				</Box>
 

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -3,7 +3,7 @@
 import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
-import { Box, Clickable, Divider, Image, Typography, useTheme } from '@/common/ui'
+import { Box, Clickable, Divider, Typography, useTheme } from '@/common/ui'
 import { alpha } from '@/common/ui/mui'
 import { Link } from '@/common/ui/Link/Link'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
@@ -11,10 +11,8 @@ import { TextField } from '@/common/ui/TextField'
 import { useSmartNavigate } from '@/routes/useSmartNavigate'
 import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
-import { getAssetUrl } from '@/tech/paths.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
-	ArrowForwardRounded,
 	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
@@ -41,28 +39,25 @@ export default SmartPage(DemoMobilePage, [
 
 const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
-const TAB_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
 const DOCKED_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
-type DemoVariant = 1 | 2 | 3 | 4 | 5
+type DemoVariant = 1 | 2 | 3 | 4
 
 /**
- * Five native list/chat/index landings, all built ONLY from real data
- * (recommended songs, recently added, search, browse-all) — no invented
- * curation features. All share the bottom tab-bar shell.
+ * One fixed recipe: docked search at the bottom, a CLEAN recommended list
+ * ("Nějaký nápad") and a COLORFUL "Poslední přidané" section. The variants
+ * differ only in how colorful the last-added section is:
  *
- * 1 — rich rows: two-line library rows with cover thumbnails, docked search
- * 2 — chat chips: assistant greeting + tappable song suggestion chips
- * 3 — chat list: assistant greeting + a song list inside a wide bubble
- * 4 — dense index: text-only sectioned list, sticky search on top
- * 5 — compact index: one-line thumbnail rows in sections, docked search
+ * 1 — carousel: horizontal square gradient cover tiles
+ * 2 — thumb rows: colorful thumbnail rows (two-line clean recommended)
+ * 3 — grid: colorful two-column gradient tiles
+ * 4 — wide cards: horizontal wide gradient cards with title + first line
  */
 function DemoMobilePage() {
 	const theme = useTheme()
 	const tHome = useTranslations('home')
 	const tNav = useTranslations('navigation')
 	const tSearch = useTranslations('search')
-	const tDemo = useTranslations('demo')
 
 	const navigate = useSmartNavigate()
 	const [query, setQuery] = useState('')
@@ -70,7 +65,7 @@ function DemoMobilePage() {
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
 	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 1
+		parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 1
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
@@ -110,23 +105,12 @@ function DemoMobilePage() {
 	const last = lastAdded.data
 	const loading = recommended.isLoading || lastAdded.isLoading
 
+	const twoLineRecommended = variant === 2
+
 	// ---- shared bits -------------------------------------------------
 
-	const searchField = (
-		<>
-			<SearchRounded sx={{ color: 'grey.600' }} />
-			<TextField
-				value={query}
-				onChange={setQuery}
-				placeholder={tSearch('searchByTitleOrText')}
-			/>
-		</>
-	)
-
 	const searchPill = (
-		<Box
-			sx={{ background: gradient, padding: '2px', borderRadius: 10, boxShadow: 3 }}
-		>
+		<Box sx={{ background: gradient, padding: '2px', borderRadius: 10, boxShadow: 3 }}>
 			<Box
 				component="form"
 				onSubmit={submitSearch}
@@ -140,43 +124,14 @@ function DemoMobilePage() {
 					paddingY: 1.5,
 				}}
 			>
-				{searchField}
+				<SearchRounded sx={{ color: 'grey.600' }} />
+				<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
 			</Box>
 		</Box>
 	)
 
-	const loginCircle = (
-		<Clickable tooltip={tNav('login')}>
-			<Link to="login" params={{ previousPage: '', message: '' }}>
-				<Box
-					aria-label={tNav('login')}
-					sx={{
-						width: 42,
-						height: 42,
-						borderRadius: 10,
-						bgcolor: 'grey.100',
-						color: 'primary.main',
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'center',
-					}}
-				>
-					<LoginRounded fontSize="small" />
-				</Box>
-			</Link>
-		</Clickable>
-	)
-
 	const header = (
-		<Box
-			sx={{
-				paddingX: 2.5,
-				paddingTop: 3,
-				display: 'flex',
-				justifyContent: 'space-between',
-				alignItems: 'end',
-			}}
-		>
+		<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
 			<Box>
 				<Typography small color="grey.700">
 					{tHome('hero.lead')}
@@ -185,20 +140,30 @@ function DemoMobilePage() {
 					{tHome('hero.title')}
 				</Typography>
 			</Box>
-			{loginCircle}
+			<Clickable tooltip={tNav('login')}>
+				<Link to="login" params={{ previousPage: '', message: '' }}>
+					<Box
+						aria-label={tNav('login')}
+						sx={{
+							width: 42,
+							height: 42,
+							borderRadius: 10,
+							bgcolor: 'grey.100',
+							color: 'primary.main',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+						}}
+					>
+						<LoginRounded fontSize="small" />
+					</Box>
+				</Link>
+			</Clickable>
 		</Box>
 	)
 
 	const label = (text: string, action?: ReactNode) => (
-		<Box
-			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'space-between',
-				gap: 1,
-				paddingX: 0.5,
-			}}
-		>
+		<Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, paddingX: 0.5 }}>
 			<Typography small strong uppercase color="grey.700">
 				{text.replace(/:$/, '')}
 			</Typography>
@@ -216,7 +181,7 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const thumb = (i: number, size = 44) => (
+	const artThumb = (i: number, size: number) => (
 		<Box
 			sx={{
 				width: size,
@@ -234,68 +199,35 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// one song row; subtitle optional, thumbnail optional
-	const songRow = (
-		s: BasicVariantPack,
-		i: number,
-		opts: { subtitle?: string; trailing?: ReactNode; showThumb?: boolean } = {}
-	) => (
-		<Clickable>
-			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-				<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25 }}>
-					{opts.showThumb && thumb(i)}
-					<Box sx={{ minWidth: 0, flex: 1 }}>
-						<Typography strong noWrap>
-							{s.title}
-						</Typography>
-						{opts.subtitle && (
-							<Typography small color="grey.700" noWrap>
-								{opts.subtitle}
-							</Typography>
-						)}
-					</Box>
-					{opts.trailing}
-					<ChevronRightRounded sx={{ color: 'grey.400' }} />
-				</Box>
-			</Link>
-		</Clickable>
-	)
+	// ---- CLEAN recommended list (white, no color) --------------------
 
-	const rowSkeletons = (n: number, h: number) =>
-		Array.from({ length: n }).map((_, i) => (
-			<Skeleton
-				key={i}
-				variant="rounded"
-				sx={{ height: h, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }}
-			/>
-		))
-
-	// a labelled list of song rows (dividers between)
-	const listSection = (
-		title: string,
-		songs: BasicVariantPack[],
-		opts: {
-			action?: ReactNode
-			offset?: number
-			showThumb?: boolean
-			subtitle?: (s: BasicVariantPack) => string
-			trailing?: (s: BasicVariantPack) => ReactNode
-			skeletonHeight?: number
-			count?: number
-		} = {}
-	) => (
+	const cleanRecommended = (
 		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
-			{label(title, opts.action)}
+			{label(tHome('recommended.idea'), browseAction)}
 			<Box sx={{ display: 'flex', flexDirection: 'column' }}>
 				{loading
-					? rowSkeletons(opts.count ?? 4, opts.skeletonHeight ?? 56)
-					: songs.slice(0, opts.count ?? 5).map((s, i, arr) => (
+					? Array.from({ length: 5 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ height: twoLineRecommended ? 52 : 40, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
+					  ))
+					: rec.slice(0, 5).map((s, i, arr) => (
 							<Fragment key={s.packGuid}>
-								{songRow(s, i + (opts.offset ?? 0), {
-									showThumb: opts.showThumb,
-									subtitle: opts.subtitle?.(s),
-									trailing: opts.trailing?.(s),
-								})}
+								<Clickable>
+									<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: twoLineRecommended ? 1.25 : 1.5 }}>
+											<Box sx={{ minWidth: 0, flex: 1 }}>
+												<Typography strong noWrap>
+													{s.title}
+												</Typography>
+												{twoLineRecommended && (
+													<Typography small color="grey.700" noWrap>
+														{firstLine(s.sheetData)}
+													</Typography>
+												)}
+											</Box>
+											<ChevronRightRounded sx={{ color: 'grey.400' }} />
+										</Box>
+									</Link>
+								</Clickable>
 								{i < arr.length - 1 && <Divider />}
 							</Fragment>
 					  ))}
@@ -303,311 +235,191 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	const dateChip = (s: BasicVariantPack) =>
-		s.publishedAt ? (
-			<Typography small color="grey.500" noWrap>
-				{getSmartDateAgoString(s.publishedAt)}
-			</Typography>
-		) : null
+	// ---- COLORFUL last-added section (four treatments) ---------------
 
-	// ---- variant 1: rich two-line rows -------------------------------
-
-	const richVariant = (
-		<>
-			{header}
-			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: DOCKED_CLEARANCE }}>
-				{listSection(tHome('recommended.idea'), rec, {
-					action: browseAction,
-					showThumb: true,
-					subtitle: (s) => firstLine(s.sheetData),
-				})}
-				{listSection(tHome('lastAdded.title'), last, {
-					offset: 2,
-					showThumb: true,
-					subtitle: (s) => firstLine(s.sheetData),
-				})}
-			</Box>
-			<DockedSearch>{searchPill}</DockedSearch>
-		</>
+	const lastLabel = (
+		<Box sx={{ paddingX: 2.5 }}>{label(tHome('lastAdded.title'))}</Box>
 	)
 
-	// ---- variant 2 & 3: chat -----------------------------------------
-
-	const bubble = (children: ReactNode) => (
-		<Box
-			sx={{
-				alignSelf: 'flex-start',
-				maxWidth: '88%',
-				bgcolor: 'grey.100',
-				borderRadius: '4px 18px 18px 18px',
-				paddingX: 2,
-				paddingY: 1.25,
-			}}
-		>
-			{children}
-		</Box>
-	)
-
-	const assistantRow = (children: ReactNode) => (
-		<Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
+	// (1) horizontal square cover tiles
+	const lastCarousel = (
+		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+			{lastLabel}
 			<Box
 				sx={{
-					width: 36,
-					height: 36,
-					borderRadius: 10,
-					bgcolor: 'grey.100',
 					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-					flexShrink: 0,
-				}}
-			>
-				<Image src={getAssetUrl('/sheeps/ovce3.svg')} alt="" width={26} height={26} />
-			</Box>
-			{children}
-		</Box>
-	)
-
-	const chatChip = (s: BasicVariantPack) => (
-		<Clickable key={s.packGuid}>
-			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-				<Box
-					sx={{
-						bgcolor: 'background.paper',
-						border: '1px solid',
-						borderColor: 'grey.300',
-						borderRadius: 10,
-						paddingX: 2,
-						paddingY: 1,
-					}}
-				>
-					<Typography small strong noWrap>
-						{s.title}
-					</Typography>
-				</Box>
-			</Link>
-		</Clickable>
-	)
-
-	const composeBar = (
-		<DockedSearch>
-			<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-				<Box
-					sx={{
-						flex: 1,
-						display: 'flex',
-						alignItems: 'center',
-						gap: 1,
-						bgcolor: 'background.paper',
-						border: '1px solid',
-						borderColor: 'grey.300',
-						borderRadius: 10,
-						paddingX: 2,
-						paddingY: 1.5,
-						boxShadow: 2,
-					}}
-				>
-					{searchField}
-				</Box>
-				<Box
-					role="button"
-					aria-label={tSearch('searchByTitleOrText')}
-					onClick={() => query.trim() && navigate('home', { hledat: query.trim() })}
-					sx={{
-						width: 48,
-						height: 48,
-						borderRadius: 10,
-						background: gradient,
-						color: 'common.white',
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'center',
-						flexShrink: 0,
-						boxShadow: 3,
-					}}
-				>
-					<ArrowForwardRounded />
-				</Box>
-			</Box>
-		</DockedSearch>
-	)
-
-	const chatChipsVariant = (
-		<>
-			{header}
-			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', flexDirection: 'column', gap: 2, paddingBottom: DOCKED_CLEARANCE }}>
-				{assistantRow(bubble(<Typography>{tDemo('assistantGreeting')}</Typography>))}
-				{bubble(
-					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-						<Typography small color="grey.700">
-							{tDemo('tryChips')}
-						</Typography>
-						<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-							{loading
-								? Array.from({ length: 4 }).map((_, i) => (
-										<Skeleton key={i} variant="rounded" sx={{ width: 120, height: 34, borderRadius: 10, bgcolor: 'grey.200' }} />
-								  ))
-								: rec.slice(0, 5).map((s) => chatChip(s))}
-						</Box>
-					</Box>
-				)}
-				{bubble(
-					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-						<Typography small color="grey.700">
-							{tHome('lastAdded.title')}
-						</Typography>
-						<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-							{!loading && last.slice(0, 4).map((s) => chatChip(s))}
-						</Box>
-					</Box>
-				)}
-			</Box>
-			{composeBar}
-		</>
-	)
-
-	const chatListVariant = (
-		<>
-			{header}
-			<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', flexDirection: 'column', gap: 2, paddingBottom: DOCKED_CLEARANCE }}>
-				{assistantRow(bubble(<Typography>{tDemo('assistantGreeting')}</Typography>))}
-				<Box
-					sx={{
-						alignSelf: 'flex-start',
-						width: '92%',
-						bgcolor: 'grey.100',
-						borderRadius: '4px 18px 18px 18px',
-						padding: 1,
-					}}
-				>
-					<Typography small color="grey.700" sx={{ paddingX: 1.5, paddingTop: 0.5 }}>
-						{tDemo('tryChips')}
-					</Typography>
-					<Box sx={{ display: 'flex', flexDirection: 'column' }}>
-						{loading
-							? rowSkeletons(4, 48)
-							: rec.slice(0, 4).map((s, i, arr) => (
-									<Fragment key={s.packGuid}>
-										<Clickable>
-											<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-												<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, padding: 1.5 }}>
-													{thumb(i, 40)}
-													<Typography strong noWrap sx={{ flex: 1 }}>
-														{s.title}
-													</Typography>
-													<ChevronRightRounded sx={{ color: 'grey.400' }} />
-												</Box>
-											</Link>
-										</Clickable>
-										{i < arr.length - 1 && <Divider sx={{ marginX: 1.5 }} />}
-									</Fragment>
-							  ))}
-					</Box>
-				</Box>
-			</Box>
-			{composeBar}
-		</>
-	)
-
-	// ---- variant 4: dense text index, sticky search ------------------
-
-	const stickyDenseVariant = (
-		<>
-			<Box
-				sx={{
-					position: 'sticky',
-					top: 0,
-					zIndex: 5,
-					bgcolor: 'background.paper',
+					gap: 1.5,
+					overflowX: 'auto',
 					paddingX: 2.5,
-					paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-					paddingBottom: 2,
-					display: 'flex',
-					flexDirection: 'column',
-					gap: 2,
-					borderBottom: '1px solid',
-					borderColor: 'grey.200',
+					paddingBottom: 0.5,
+					scrollSnapType: 'x mandatory',
+					'&::-webkit-scrollbar': { display: 'none' },
 				}}
 			>
-				<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
-					<Box>
-						<Typography small color="grey.700">
-							{tHome('hero.lead')}
-						</Typography>
-						<Typography variant="h3" strong={800}>
-							{tHome('hero.title')}
-						</Typography>
-					</Box>
-					{loginCircle}
-				</Box>
-				<Box
-					component="form"
-					onSubmit={submitSearch}
-					sx={{
-						display: 'flex',
-						alignItems: 'center',
-						gap: 1,
-						bgcolor: 'grey.100',
-						borderRadius: 3,
-						paddingX: 2,
-						paddingY: 1.5,
-					}}
-				>
-					{searchField}
-				</Box>
+				{loading
+					? Array.from({ length: 4 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ minWidth: 128, height: 160, borderRadius: 3, bgcolor: 'grey.200' }} />
+					  ))
+					: last.slice(0, 8).map((s, i) => (
+							<Clickable key={s.packGuid}>
+								<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+									<Box sx={{ width: 128, display: 'flex', flexDirection: 'column', gap: 1 }}>
+										<Box
+											sx={{
+												width: 128,
+												height: 128,
+												borderRadius: 3,
+												background: artFor(i),
+												color: 'common.white',
+												display: 'flex',
+												alignItems: 'flex-end',
+												padding: 1.25,
+												boxShadow: 1,
+											}}
+										>
+											<MusicNoteRounded />
+										</Box>
+										<Typography strong noWrap sx={{ paddingX: 0.5 }}>
+											{s.title}
+										</Typography>
+									</Box>
+								</Link>
+							</Clickable>
+					  ))}
 			</Box>
-			<Box sx={{ paddingTop: 2, display: 'flex', flexDirection: 'column', gap: 2.5, paddingBottom: TAB_CLEARANCE }}>
-				{listSection(tHome('recommended.idea'), rec, {
-					action: browseAction,
-					count: 5,
-					skeletonHeight: 44,
-				})}
-				{listSection(tHome('lastAdded.title'), last, {
-					offset: 2,
-					count: 5,
-					skeletonHeight: 44,
-					trailing: dateChip,
-				})}
-			</Box>
-		</>
+		</Box>
 	)
 
-	// ---- variant 5: compact thumbnail index, docked search -----------
-
-	const compactVariant = (
-		<>
-			{header}
-			<Box sx={{ paddingTop: 2.5, display: 'flex', flexDirection: 'column', gap: 2.5, paddingBottom: DOCKED_CLEARANCE }}>
-				{listSection(tHome('recommended.idea'), rec, {
-					action: browseAction,
-					showThumb: true,
-					count: 5,
-					skeletonHeight: 48,
-				})}
-				{listSection(tHome('lastAdded.title'), last, {
-					offset: 2,
-					showThumb: true,
-					count: 5,
-					skeletonHeight: 48,
-					trailing: dateChip,
-				})}
+	// (2) colorful thumbnail rows
+	const lastThumbRows = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+			{label(tHome('lastAdded.title'))}
+			<Box sx={{ display: 'flex', flexDirection: 'column' }}>
+				{loading
+					? Array.from({ length: 4 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
+					  ))
+					: last.slice(0, 5).map((s, i, arr) => (
+							<Fragment key={s.packGuid}>
+								<Clickable>
+									<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1 }}>
+											{artThumb(i, 44)}
+											<Typography strong noWrap sx={{ flex: 1 }}>
+												{s.title}
+											</Typography>
+											{s.publishedAt && (
+												<Typography small color="grey.500" noWrap>
+													{getSmartDateAgoString(s.publishedAt)}
+												</Typography>
+											)}
+											<ChevronRightRounded sx={{ color: 'grey.400' }} />
+										</Box>
+									</Link>
+								</Clickable>
+								{i < arr.length - 1 && <Divider />}
+							</Fragment>
+					  ))}
 			</Box>
-			<DockedSearch>{searchPill}</DockedSearch>
-		</>
+		</Box>
 	)
 
-	// ------------------------------------------------------------------
+	// (3) colorful two-column gradient tiles
+	const lastGrid = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+			{label(tHome('lastAdded.title'))}
+			<Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5 }}>
+				{loading
+					? Array.from({ length: 4 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ height: 110, borderRadius: 3, bgcolor: 'grey.200' }} />
+					  ))
+					: last.slice(0, 6).map((s, i) => (
+							<Clickable key={s.packGuid}>
+								<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+									<Box
+										sx={{
+											height: 110,
+											borderRadius: 3,
+											background: artFor(i),
+											color: 'common.white',
+											padding: 1.5,
+											display: 'flex',
+											flexDirection: 'column',
+											justifyContent: 'space-between',
+											boxShadow: 1,
+										}}
+									>
+										<MusicNoteRounded fontSize="small" />
+										<Typography strong noWrap>
+											{s.title}
+										</Typography>
+									</Box>
+								</Link>
+							</Clickable>
+					  ))}
+			</Box>
+		</Box>
+	)
 
-	const body =
+	// (4) horizontal wide gradient cards
+	const lastWideCards = (
+		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+			{lastLabel}
+			<Box
+				sx={{
+					display: 'flex',
+					gap: 1.5,
+					overflowX: 'auto',
+					paddingX: 2.5,
+					paddingBottom: 0.5,
+					scrollSnapType: 'x mandatory',
+					'&::-webkit-scrollbar': { display: 'none' },
+				}}
+			>
+				{loading
+					? Array.from({ length: 3 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ minWidth: 260, height: 104, borderRadius: 3, bgcolor: 'grey.200' }} />
+					  ))
+					: last.slice(0, 8).map((s, i) => (
+							<Clickable key={s.packGuid}>
+								<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+									<Box
+										sx={{
+											width: 260,
+											height: 104,
+											borderRadius: 3,
+											background: artFor(i),
+											color: 'common.white',
+											padding: 2,
+											display: 'flex',
+											flexDirection: 'column',
+											justifyContent: 'space-between',
+											boxShadow: 1,
+											scrollSnapAlign: 'start',
+										}}
+									>
+										<Typography strong noWrap>
+											{s.title}
+										</Typography>
+										<Typography small noWrap sx={{ opacity: 0.9 }}>
+											{firstLine(s.sheetData)}
+										</Typography>
+									</Box>
+								</Link>
+							</Clickable>
+					  ))}
+			</Box>
+		</Box>
+	)
+
+	const lastSection =
 		variant === 1
-			? richVariant
+			? lastCarousel
 			: variant === 2
-			? chatChipsVariant
+			? lastThumbRows
 			: variant === 3
-			? chatListVariant
-			: variant === 4
-			? stickyDenseVariant
-			: compactVariant
+			? lastGrid
+			: lastWideCards
 
 	return (
 		<Box
@@ -636,7 +448,14 @@ function DemoMobilePage() {
 					position: 'relative',
 				}}
 			>
-				{body}
+				{header}
+				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: DOCKED_CLEARANCE }}>
+					{cleanRecommended}
+					{lastSection}
+				</Box>
+
+				{/* ===== Docked search — floats above the tab bar (thumb zone) ===== */}
+				<DockedSearch>{searchPill}</DockedSearch>
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}
 				<Box

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -49,7 +49,7 @@ const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const TAB_BAR_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
 const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
-type DemoVariant = 1 | 2 | 3 | 4
+type DemoVariant = 1 | 2 | 3 | 4 | 5
 
 /**
  * Variants — all share the "cards" language, they differ in where the
@@ -64,6 +64,8 @@ type DemoVariant = 1 | 2 | 3 | 4
  * 4 — polished blue system: white canvas, neutral grey panels, blue used
  *     only as accent (badges, actions, button, tab pill); search docked
  *     bottom with a solid blue border
+ * 5 — Google-style minimal: an almost empty white page with just the
+ *     brand, the search and one quiet action in the middle
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -78,7 +80,7 @@ function DemoMobilePage() {
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
 	const variant: DemoVariant =
-		parsed === 2 || parsed === 3 || parsed === 4 ? (parsed as DemoVariant) : 1
+		parsed >= 2 && parsed <= 5 ? (parsed as DemoVariant) : 1
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
@@ -86,13 +88,15 @@ function DemoMobilePage() {
 	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
 
 	const blueSystem = variant === 4
+	const googleMinimal = variant === 5
 	const searchDocked = variant === 2 || variant === 4
 	const searchCentered = variant === 3
-	const showLastAdded = !searchCentered
+	const showLastAdded = !searchCentered && !googleMinimal
 
 	// One card language per variant: v1–v3 white cards on grey canvas,
 	// v4 neutral grey panels on white canvas with blue accents only
-	const canvasBg = blueSystem ? 'background.paper' : 'grey.100'
+	const canvasBg =
+		blueSystem || googleMinimal ? 'background.paper' : 'grey.100'
 	const panelBg = blueSystem ? 'grey.100' : 'background.paper'
 	const panelShadow = blueSystem ? 0 : 1
 	const rowsHaveDividers = !blueSystem
@@ -376,7 +380,68 @@ function DemoMobilePage() {
 				}}
 			>
 				{/* ===================== HEADER (+ top/centered search) ===================== */}
-				{searchCentered ? (
+				{googleMinimal ? (
+					// Google-style: an almost empty page — brand + search in the
+					// middle, one quiet action, nothing else
+					<Box
+						sx={{
+							flex: 1,
+							display: 'flex',
+							flexDirection: 'column',
+							paddingX: 4,
+							paddingTop: 'calc(env(safe-area-inset-top) + 16px)',
+							paddingBottom: TAB_BAR_CLEARANCE,
+						}}
+					>
+						<Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+							{loginLink}
+						</Box>
+						<Box sx={{ flex: 0.85 }} />
+						<Box
+							sx={{
+								display: 'flex',
+								flexDirection: 'column',
+								alignItems: 'center',
+								gap: 3,
+							}}
+						>
+							{sheep(96)}
+							<Box sx={{ textAlign: 'center' }}>
+								<Typography small color="grey.700">
+									{tHome('hero.lead')}
+								</Typography>
+								<Typography variant="h3" strong={800}>
+									{tHome('hero.title')}
+								</Typography>
+							</Box>
+							<Box sx={{ width: '100%' }}>{searchForm}</Box>
+							<Clickable>
+								<Link to="songsList" params={{ s: undefined }}>
+									<Box
+										sx={{
+											display: 'flex',
+											alignItems: 'center',
+											gap: 1,
+											bgcolor: 'grey.100',
+											borderRadius: 10,
+											paddingX: 2.5,
+											paddingY: 1,
+										}}
+									>
+										<QueueMusicRounded
+											fontSize="small"
+											sx={{ color: 'grey.700' }}
+										/>
+										<Typography small strong>
+											{tHome('allList.title')}
+										</Typography>
+									</Box>
+								</Link>
+							</Clickable>
+						</Box>
+						<Box sx={{ flex: 1.15 }} />
+					</Box>
+				) : searchCentered ? (
 					// hero fills the upper half so the search lands mid-screen,
 					// inside comfortable thumb reach
 					<Box
@@ -420,6 +485,7 @@ function DemoMobilePage() {
 				)}
 
 				{/* ===================== SECTIONS ===================== */}
+				{!googleMinimal && (
 				<Box
 					sx={{
 						flex: 1,
@@ -587,6 +653,7 @@ function DemoMobilePage() {
 						</Box>
 					)}
 				</Box>
+				)}
 
 				{/* ===== Docked search — floats above the tab bar (thumb zone) ===== */}
 				{searchDocked && (
@@ -598,7 +665,10 @@ function DemoMobilePage() {
 							transform: 'translateX(-50%)',
 							width: '100%',
 							maxWidth: PAGE_MAX_WIDTH,
-							paddingX: 2.5,
+							paddingX: 4,
+							// no global border-box in this app — keep the padding
+							// inside the 100% width instead of overflowing it
+							boxSizing: 'border-box',
 							zIndex: 10,
 						}}
 					>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -44,14 +44,15 @@ type DemoVariant = 1 | 2 | 3 | 4
 
 /**
  * Grey canvas + white cards for the picks; the recent section is the quiet
- * airy list (subtle M1 look). The SEARCH has NO button — instead a primary
- * gradient border (same look as the desktop MainSearchInput) draws the eye,
- * with the full placeholder. Variants tune the border + inner field:
+ * airy list (subtle M1 look). The SEARCH is buttonless with a primary
+ * gradient border (desktop MainSearchInput look). A WHITE hero zone wraps the
+ * header + the "some idea" label and ends just past it, so the white cards
+ * below read as floating on the grey canvas. Variants tune that white zone:
  *
- * 1 — thin gradient border, white inner field (default)
- * 2 — thicker gradient border, white inner field
- * 3 — thin gradient border, subtle grey inner field (matches desktop)
- * 4 — thin gradient border, white inner field, primary-tinted search icon
+ * 1 — straight edge, ends just past the label (default)
+ * 2 — rounded bottom corners (sheet look)
+ * 3 — extends further down, toward the first card
+ * 4 — straight edge with a soft drop shadow under the white zone
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -99,7 +100,7 @@ function DemoMobilePage() {
 				<Link to="login" params={{ previousPage: '', message: '' }}>
 					<Box
 						aria-label={tNav('login')}
-						sx={{ width: 42, height: 42, borderRadius: 10, bgcolor: 'background.paper', color: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: 1 }}
+						sx={{ width: 42, height: 42, borderRadius: 10, bgcolor: 'grey.100', color: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
 					>
 						<LoginRounded fontSize="small" />
 					</Box>
@@ -127,20 +128,19 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	// ---- picks: white cards on the grey canvas -----------------------
+	// ---- picks: label lives in the white hero, cards float on grey ---
 
-	const picks = (
-		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-			{label(tHome('recommended.idea'), browseAction)}
-			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-				{loading
-					? Array.from({ length: 4 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
-					  ))
-					: rec.slice(0, 5).map((s) => (
-							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1 }} />
-					  ))}
-			</Box>
+	const picksLabel = <Box sx={{ paddingX: 2.5 }}>{label(tHome('recommended.idea'), browseAction)}</Box>
+
+	const picksCards = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+			{loading
+				? Array.from({ length: 4 }).map((_, i) => (
+						<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
+				  ))
+				: rec.slice(0, 5).map((s) => (
+						<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1 }} />
+				  ))}
 		</Box>
 	)
 
@@ -186,10 +186,6 @@ function DemoMobilePage() {
 
 	// ---- search: no button, primary gradient border draws the eye ----
 
-	const borderThickness = variant === 2 ? '3px' : '2px'
-	const innerBg = variant === 3 ? 'grey.50' : 'background.paper'
-	const iconColor = variant === 4 ? 'primary.main' : 'grey.500'
-
 	const search = (
 		<Box
 			component="form"
@@ -200,7 +196,7 @@ function DemoMobilePage() {
 			sx={{
 				background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
 				borderRadius: 2,
-				padding: borderThickness,
+				padding: '2px',
 				boxShadow: 2,
 			}}
 		>
@@ -209,18 +205,40 @@ function DemoMobilePage() {
 					display: 'flex',
 					alignItems: 'center',
 					gap: 1,
-					bgcolor: innerBg,
+					bgcolor: 'background.paper',
 					borderRadius: 1.75,
 					paddingX: 1.75,
 					paddingY: 1.25,
 					minWidth: 0,
 				}}
 			>
-				<SearchRounded sx={{ color: iconColor, fontSize: 20 }} />
+				<SearchRounded sx={{ color: 'grey.500', fontSize: 20 }} />
 				<Box sx={{ flex: 1, minWidth: 0 }}>
 					<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
 				</Box>
 			</Box>
+		</Box>
+	)
+
+	// ---- white hero zone: wraps the header + label, ends past it ------
+
+	const heroRounded = variant === 2 // rounded bottom corners (sheet look)
+	const heroPadBottom = variant === 3 ? 3 : 1.5 // 3 = white extends further down
+	const heroShadow = variant === 4 // soft drop shadow under the white zone
+
+	const hero = (
+		<Box
+			sx={{
+				bgcolor: 'background.paper',
+				paddingBottom: heroPadBottom,
+				...(heroRounded && { borderBottomLeftRadius: 4, borderBottomRightRadius: 4 }),
+				...(heroShadow && { boxShadow: '0 6px 14px rgba(0,0,0,0.06)' }),
+				position: 'relative',
+				zIndex: 1,
+			}}
+		>
+			{header}
+			<Box sx={{ paddingTop: 1 }}>{picksLabel}</Box>
 		</Box>
 	)
 
@@ -250,9 +268,9 @@ function DemoMobilePage() {
 					position: 'relative',
 				}}
 			>
-				{header}
-				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: CONTENT_CLEARANCE }}>
-					{picks}
+				{hero}
+				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 1.5, paddingBottom: CONTENT_CLEARANCE }}>
+					{picksCards}
 					{recent}
 				</Box>
 

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
-import MainSearchInput from '@/app/components/components/MainSearchInput'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
 import { Box, Clickable, Typography, useTheme } from '@/common/ui'
@@ -9,10 +8,13 @@ import { alpha } from '@/common/ui/mui'
 import { Link } from '@/common/ui/Link/Link'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
 import { SongVariantCard } from '@/common/ui/SongCard'
+import { TextField } from '@/common/ui/TextField'
+import { useSmartNavigate } from '@/routes/useSmartNavigate'
 import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
+	ArrowForwardRounded,
 	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
@@ -21,6 +23,7 @@ import {
 	LoginRounded,
 	PersonOutlineRounded,
 	PersonRounded,
+	SearchRounded,
 } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useState } from 'react'
@@ -38,21 +41,23 @@ const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const TAB_BAR = 'calc(env(safe-area-inset-bottom) + 64px)'
 const CONTENT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 176px)'
 
-type DemoVariant = 1 | 2 | 3
+type DemoVariant = 1 | 2 | 3 | 4
 
 /**
- * Grey canvas + white cards for the picks (the liked G3 look). The recent
- * section is the L3 airy list (title + date + chevron). Variants only turn
- * DOWN its prominence so it recedes further under the picks:
+ * Grey canvas + white cards for the picks; the recent section is the quiet
+ * airy list (subtle M1 look). The SEARCH now has a blue submit button built
+ * into the field so it stands out — variants tune that button:
  *
- * 1 — subtle: dark-grey titles
- * 2 — muted: smaller, grey titles (default)
- * 3 — faint: small thin light-grey titles, barely there
+ * 1 — blue square button, grey elevated field (default)
+ * 2 — blue square button, white bordered field
+ * 3 — blue rounded "D" cap on a pill field
+ * 4 — blue button with a "HLEDAT" label
  */
 function DemoMobilePage() {
 	const theme = useTheme()
 	const tHome = useTranslations('home')
 	const tNav = useTranslations('navigation')
+	const tSearch = useTranslations('search')
 
 	const [query, setQuery] = useState('')
 
@@ -62,9 +67,12 @@ function DemoMobilePage() {
 	const last = lastAdded.data
 	const loading = recommended.isLoading || lastAdded.isLoading
 
+	const navigate = useSmartNavigate()
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	const variant: DemoVariant = parsed >= 1 && parsed <= 3 ? (parsed as DemoVariant) : 2
+	const variant: DemoVariant = parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 1
+
+	const submit = () => query.trim() && navigate('home', { hledat: query.trim() })
 
 	// ---- header ------------------------------------------------------
 
@@ -147,17 +155,14 @@ function DemoMobilePage() {
 			))
 		}
 
-		// airy list (title + date + chevron), dialled DOWN by mute level
-		const titleColor = variant === 1 ? 'grey.700' : variant === 2 ? 'grey.600' : 'grey.500'
-		const titleSmall = variant >= 2
-		const titleThin = variant === 3
+		// quiet airy list (M1): dark-grey titles + muted date + faint chevron
 		return (
-			<Box sx={{ display: 'flex', flexDirection: 'column', gap: variant === 1 ? 0.5 : 0.25 }}>
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
 				{last.slice(0, 5).map((s) => (
 					<Clickable key={s.packGuid}>
 						<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-							<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: variant === 1 ? 1 : 0.75 }}>
-								<Typography small={titleSmall} thin={titleThin} color={titleColor} noWrap sx={{ flex: 1 }}>
+							<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1 }}>
+								<Typography color="grey.700" noWrap sx={{ flex: 1 }}>
 									{s.title}
 								</Typography>
 								<Typography small color="grey.400" noWrap>
@@ -179,10 +184,59 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// ---- search ------------------------------------------------------
+	// ---- search: field with a blue submit button built in ------------
+
+	const pill = variant === 3
+	const withLabel = variant === 4
+	const outlined = variant === 2
 
 	const search = (
-		<MainSearchInput gradientBorder={false} value={query} onChange={setQuery} autoFocus={false} />
+		<Box
+			component="form"
+			onSubmit={(e) => {
+				e.preventDefault()
+				submit()
+			}}
+			sx={{
+				display: 'flex',
+				alignItems: 'stretch',
+				bgcolor: outlined ? 'background.paper' : 'grey.100',
+				...(outlined && { border: '1px solid', borderColor: 'grey.300' }),
+				borderRadius: pill ? 10 : 2.5,
+				overflow: 'hidden',
+				boxShadow: 2,
+			}}
+		>
+			<Box sx={{ flex: 1, display: 'flex', alignItems: 'center', gap: 1, paddingLeft: 2, paddingY: 1.5, minWidth: 0 }}>
+				<SearchRounded sx={{ color: 'grey.600' }} />
+				<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
+			</Box>
+			<Box
+				role="button"
+				aria-label={tSearch('searchByTitleOrText')}
+				onClick={submit}
+				sx={{
+					bgcolor: 'primary.main',
+					color: 'common.white',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					gap: 0.75,
+					paddingX: withLabel ? 2.25 : 2.5,
+					cursor: 'pointer',
+					flexShrink: 0,
+					transition: 'background-color 0.15s',
+					'&:hover': { bgcolor: 'primary.dark' },
+				}}
+			>
+				<ArrowForwardRounded fontSize="small" />
+				{withLabel && (
+					<Typography small strong uppercase color="common.white">
+						{tNav('search')}
+					</Typography>
+				)}
+			</Box>
+		</Box>
 	)
 
 	return (

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -43,8 +43,6 @@ const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 
 // bottom layout metrics (kept in sync so nothing hides / crowds)
 const TAB_BAR = 'calc(env(safe-area-inset-bottom) + 64px)'
-const FLOAT_SEARCH_BOTTOM = 'calc(env(safe-area-inset-bottom) + 88px)'
-const FLOAT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 188px)'
 const CONNECTED_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 148px)'
 
 type DemoVariant = 1 | 2 | 3 | 4 | 5
@@ -71,9 +69,9 @@ function DemoMobilePage() {
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	// connected square search bar (3) is the picked default
+	// soft-square connected search (2) is the closest to the picked look
 	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 3
+		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 2
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
@@ -112,8 +110,9 @@ function DemoMobilePage() {
 	const last = lastAdded.data
 	const loading = recommended.isLoading || lastAdded.isLoading
 
-	const isConnected = variant === 3
-	const contentClearance = isConnected ? CONNECTED_CLEARANCE : FLOAT_CLEARANCE
+	// all variants use the connected square search bar; they differ only in
+	// the field's corner sharpness / fill / accent
+	const contentClearance = CONNECTED_CLEARANCE
 
 	// ---- header ------------------------------------------------------
 
@@ -267,112 +266,70 @@ function DemoMobilePage() {
 
 	// ---- search treatments -------------------------------------------
 
-	const fieldInner = (
-		<>
-			<SearchRounded sx={{ color: 'grey.600' }} />
-			<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
-		</>
+	const textInput = (
+		<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
 	)
+	const plainIcon = <SearchRounded sx={{ color: 'grey.600' }} />
 
-	// 1 — gradient-border pill
-	const gradientPill = (
-		<Box sx={{ background: gradient, padding: '2px', borderRadius: 10, boxShadow: 3 }}>
-			<Box
-				component="form"
-				onSubmit={submitSearch}
-				sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'background.paper', borderRadius: 10, paddingX: 2, paddingY: 1.5 }}
-			>
-				{fieldInner}
+	// Square connected search field — five tunings of the "hranatý" look.
+	// radius is in theme units (1 ≈ 4px), so 0.75→3px is nearly sharp.
+	const squareField = () => {
+		// 1 — sharp: almost square corners, soft grey fill
+		if (variant === 1) {
+			return (
+				<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'grey.100', borderRadius: 0.75, paddingX: 2, paddingY: 1.5 }}>
+					{plainIcon}
+					{textInput}
+				</Box>
+			)
+		}
+		// 2 — soft square: gently rounded rectangle (the picked S3 look)
+		if (variant === 2) {
+			return (
+				<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'grey.100', borderRadius: 2.5, paddingX: 2, paddingY: 1.5 }}>
+					{plainIcon}
+					{textInput}
+				</Box>
+			)
+		}
+		// 3 — outlined: white field with a thin border, square-ish
+		if (variant === 3) {
+			return (
+				<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'background.paper', border: '1px solid', borderColor: 'grey.300', borderRadius: 1.25, paddingX: 2, paddingY: 1.5 }}>
+					{plainIcon}
+					{textInput}
+				</Box>
+			)
+		}
+		// 4 — accent icon: square field with a gradient icon tile on the left
+		if (variant === 4) {
+			return (
+				<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1.25, bgcolor: 'grey.100', borderRadius: 1.5, paddingLeft: 1, paddingRight: 2, paddingY: 1 }}>
+					<Box sx={{ width: 36, height: 36, borderRadius: 1.25, background: gradient, color: 'common.white', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+						<SearchRounded fontSize="small" />
+					</Box>
+					{textInput}
+				</Box>
+			)
+		}
+		// 5 — with submit: square field + square gradient submit button
+		return (
+			<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+				<Box sx={{ flex: 1, display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'grey.100', borderRadius: 1.5, paddingX: 2, paddingY: 1.5 }}>
+					{plainIcon}
+					{textInput}
+				</Box>
+				<Box
+					role="button"
+					aria-label={tSearch('searchByTitleOrText')}
+					onClick={() => query.trim() && navigate('home', { hledat: query.trim() })}
+					sx={{ width: 48, height: 48, borderRadius: 1.5, background: gradient, color: 'common.white', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, boxShadow: 2 }}
+				>
+					<ArrowForwardRounded />
+				</Box>
 			</Box>
-		</Box>
-	)
-
-	// 2 — soft filled pill
-	const filledPill = (
-		<Box
-			component="form"
-			onSubmit={submitSearch}
-			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				gap: 1,
-				bgcolor: 'grey.100',
-				borderRadius: 10,
-				paddingX: 2,
-				paddingY: 1.75,
-				boxShadow: 2,
-			}}
-		>
-			{fieldInner}
-		</Box>
-	)
-
-	// 4 — filled field + circular gradient submit
-	const composeBar = (
-		<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-			<Box
-				sx={{
-					flex: 1,
-					display: 'flex',
-					alignItems: 'center',
-					gap: 1,
-					bgcolor: 'background.paper',
-					border: '1px solid',
-					borderColor: 'grey.300',
-					borderRadius: 10,
-					paddingX: 2,
-					paddingY: 1.5,
-					boxShadow: 2,
-				}}
-			>
-				{fieldInner}
-			</Box>
-			<Box
-				role="button"
-				aria-label={tSearch('searchByTitleOrText')}
-				onClick={() => query.trim() && navigate('home', { hledat: query.trim() })}
-				sx={{
-					width: 48,
-					height: 48,
-					borderRadius: 10,
-					background: gradient,
-					color: 'common.white',
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-					flexShrink: 0,
-					boxShadow: 3,
-				}}
-			>
-				<ArrowForwardRounded />
-			</Box>
-		</Box>
-	)
-
-	// 5 — outlined white pill
-	const outlinedPill = (
-		<Box
-			component="form"
-			onSubmit={submitSearch}
-			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				gap: 1,
-				bgcolor: 'background.paper',
-				border: '1.5px solid',
-				borderColor: 'primary.main',
-				borderRadius: 10,
-				paddingX: 2,
-				paddingY: 1.5,
-				boxShadow: 1,
-			}}
-		>
-			{fieldInner}
-		</Box>
-	)
-
-	const floatingSearch =
-		variant === 1 ? gradientPill : variant === 2 ? filledPill : variant === 4 ? composeBar : outlinedPill
+		)
+	}
 
 	return (
 		<Box
@@ -407,54 +364,27 @@ function DemoMobilePage() {
 					{recentSection}
 				</Box>
 
-				{/* ===== SEARCH: floating pill above the tab bar (thumb zone) ===== */}
-				{!isConnected && (
-					<Box
-						sx={{
-							position: 'fixed',
-							bottom: FLOAT_SEARCH_BOTTOM,
-							left: '50%',
-							transform: 'translateX(-50%)',
-							width: '100%',
-							maxWidth: PAGE_MAX_WIDTH,
-							paddingX: 4,
-							boxSizing: 'border-box',
-							zIndex: 10,
-						}}
-					>
-						{floatingSearch}
-					</Box>
-				)}
-
-				{/* ===== SEARCH: full-width bar connected to the tab bar ===== */}
-				{isConnected && (
-					<Box
-						sx={{
-							position: 'fixed',
-							bottom: TAB_BAR,
-							left: '50%',
-							transform: 'translateX(-50%)',
-							width: '100%',
-							maxWidth: PAGE_MAX_WIDTH,
-							bgcolor: alpha(theme.palette.background.paper, 0.85),
-							backdropFilter: 'blur(12px)',
-							borderTop: '1px solid',
-							borderColor: 'grey.200',
-							paddingX: 2.5,
-							paddingY: 1.25,
-							boxSizing: 'border-box',
-							zIndex: 10,
-						}}
-					>
-						<Box
-							component="form"
-							onSubmit={submitSearch}
-							sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'grey.100', borderRadius: 3, paddingX: 2, paddingY: 1.25 }}
-						>
-							{fieldInner}
-						</Box>
-					</Box>
-				)}
+				{/* ===== SEARCH: full-width square bar connected to the tab bar ===== */}
+				<Box
+					sx={{
+						position: 'fixed',
+						bottom: TAB_BAR,
+						left: '50%',
+						transform: 'translateX(-50%)',
+						width: '100%',
+						maxWidth: PAGE_MAX_WIDTH,
+						bgcolor: alpha(theme.palette.background.paper, 0.85),
+						backdropFilter: 'blur(12px)',
+						borderTop: '1px solid',
+						borderColor: 'grey.200',
+						paddingX: 2.5,
+						paddingY: 1.25,
+						boxSizing: 'border-box',
+						zIndex: 10,
+					}}
+				>
+					{squareField()}
+				</Box>
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}
 				<Box

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
 import { Box, Clickable, Divider, Typography, useTheme } from '@/common/ui'
@@ -10,7 +9,6 @@ import { Skeleton } from '@/common/ui/mui/Skeleton'
 import { TextField } from '@/common/ui/TextField'
 import { useSmartNavigate } from '@/routes/useSmartNavigate'
 import { useSmartParams } from '@/routes/useSmartParams'
-import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
 	ChevronRightRounded,
@@ -19,7 +17,6 @@ import {
 	LibraryMusicOutlined,
 	LibraryMusicRounded,
 	LoginRounded,
-	MusicNoteRounded,
 	PersonOutlineRounded,
 	PersonRounded,
 	SearchRounded,
@@ -27,7 +24,6 @@ import {
 import { Sheet } from '@pepavlin/sheet-api'
 import { useTranslations } from 'next-intl'
 import { Fragment, ReactNode, useState } from 'react'
-import { BasicVariantPack } from '../../../api/dtos'
 
 export default SmartPage(DemoMobilePage, [
 	'hideToolbar',
@@ -73,19 +69,6 @@ function DemoMobilePage() {
 		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 2
 
 	const recommended = useRecommendedSongs()
-	const lastAdded = useLastAddedSongs()
-
-	const p = theme.palette
-	const gradient = `linear-gradient(135deg, ${p.primary.main}, ${p.primary.dark})`
-
-	const artGradients = [
-		`linear-gradient(135deg, ${p.primary.main}, ${p.primary.dark})`,
-		`linear-gradient(135deg, ${p.info.main}, ${p.primary.main})`,
-		`linear-gradient(135deg, ${p.success.main}, ${p.info.main})`,
-		`linear-gradient(135deg, ${p.secondary.main}, ${p.warning.main})`,
-		`linear-gradient(135deg, ${p.primary.dark}, ${p.error.main})`,
-	]
-	const artFor = (i: number) => artGradients[i % artGradients.length]
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
@@ -106,8 +89,7 @@ function DemoMobilePage() {
 	}
 
 	const rec = recommended.data
-	const last = lastAdded.data
-	const loading = recommended.isLoading || lastAdded.isLoading
+	const loading = recommended.isLoading
 
 	// all variants use the connected square search bar; they differ only in
 	// the field's corner sharpness / fill / accent
@@ -176,23 +158,6 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const artThumb = (i: number) => (
-		<Box
-			sx={{
-				width: 46,
-				height: 46,
-				borderRadius: 2,
-				background: artFor(i),
-				color: 'common.white',
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'center',
-				flexShrink: 0,
-			}}
-		>
-			<MusicNoteRounded fontSize="small" />
-		</Box>
-	)
 
 	// ---- body sections (consistent geometry) -------------------------
 
@@ -218,40 +183,6 @@ function DemoMobilePage() {
 													{firstLine(s.sheetData)}
 												</Typography>
 											</Box>
-											<ChevronRightRounded sx={{ color: 'grey.400' }} />
-										</Box>
-									</Link>
-								</Clickable>
-								{i < arr.length - 1 && <Divider />}
-							</Fragment>
-					  ))}
-			</Box>
-		</Box>
-	)
-
-	// colorful recent — thumbnail rows, same row rhythm as above
-	const recentSection = (
-		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-			{label(tHome('lastAdded.title'))}
-			<Box sx={{ display: 'flex', flexDirection: 'column' }}>
-				{loading
-					? Array.from({ length: 5 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ height: 58, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
-					  ))
-					: last.slice(0, 5).map((s, i, arr) => (
-							<Fragment key={s.packGuid}>
-								<Clickable>
-									<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1 }}>
-											{artThumb(i)}
-											<Typography strong noWrap sx={{ flex: 1 }}>
-												{s.title}
-											</Typography>
-											{s.publishedAt && (
-												<Typography small color="grey.500" noWrap>
-													{getSmartDateAgoString(s.publishedAt)}
-												</Typography>
-											)}
 											<ChevronRightRounded sx={{ color: 'grey.400' }} />
 										</Box>
 									</Link>
@@ -339,7 +270,6 @@ function DemoMobilePage() {
 				{header}
 				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: contentClearance }}>
 					{recommendedSection}
-					{recentSection}
 				</Box>
 
 				{/* ===== SEARCH: grey elevated field above the tab bar ===== */}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -13,7 +13,6 @@ import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
-	ArrowForwardRounded,
 	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
@@ -48,15 +47,15 @@ const CONNECTED_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 148px)'
 type DemoVariant = 1 | 2 | 3 | 4 | 5
 
 /**
- * The picked C2 recipe (clean two-line picks + colorful recent rows),
- * cleaned up with consistent spacing. The variants only change the SEARCH
- * bar treatment:
+ * The picked recipe (clean two-line picks + colorful recent rows) with a
+ * grey square search field, no button. The variants only tune the field's
+ * DROP SHADOW / elevation so it pops and pulls attention:
  *
- * 1 — gradient pill: floating rounded pill with brand gradient border
- * 2 — filled pill: floating soft grey pill (subtle)
- * 3 — connected bar: full-width field attached directly above the tab bar
- * 4 — compose: floating field + circular gradient submit button
- * 5 — outlined pill: floating white pill with a thin primary border
+ * 1 — soft: subtle lift
+ * 2 — medium: clearly elevated (default)
+ * 3 — strong: prominent float
+ * 4 — brand glow: primary-tinted shadow
+ * 5 — floating: detached grey field over a transparent bar
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -271,65 +270,44 @@ function DemoMobilePage() {
 	)
 	const plainIcon = <SearchRounded sx={{ color: 'grey.600' }} />
 
-	// Square connected search field — five tunings of the "hranatý" look.
-	// radius is in theme units (1 ≈ 4px), so 0.75→3px is nearly sharp.
-	const squareField = () => {
-		// 1 — sharp: almost square corners, soft grey fill
-		if (variant === 1) {
-			return (
-				<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'grey.100', borderRadius: 0.75, paddingX: 2, paddingY: 1.5 }}>
-					{plainIcon}
-					{textInput}
-				</Box>
-			)
-		}
-		// 2 — soft square: gently rounded rectangle (the picked S3 look)
-		if (variant === 2) {
-			return (
-				<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'grey.100', borderRadius: 2.5, paddingX: 2, paddingY: 1.5 }}>
-					{plainIcon}
-					{textInput}
-				</Box>
-			)
-		}
-		// 3 — outlined: white field with a thin border, square-ish
-		if (variant === 3) {
-			return (
-				<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'background.paper', border: '1px solid', borderColor: 'grey.300', borderRadius: 1.25, paddingX: 2, paddingY: 1.5 }}>
-					{plainIcon}
-					{textInput}
-				</Box>
-			)
-		}
-		// 4 — accent icon: square field with a gradient icon tile on the left
-		if (variant === 4) {
-			return (
-				<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1.25, bgcolor: 'grey.100', borderRadius: 1.5, paddingLeft: 1, paddingRight: 2, paddingY: 1 }}>
-					<Box sx={{ width: 36, height: 36, borderRadius: 1.25, background: gradient, color: 'common.white', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-						<SearchRounded fontSize="small" />
-					</Box>
-					{textInput}
-				</Box>
-			)
-		}
-		// 5 — with submit: square field + square gradient submit button
-		return (
-			<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-				<Box sx={{ flex: 1, display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'grey.100', borderRadius: 1.5, paddingX: 2, paddingY: 1.5 }}>
-					{plainIcon}
-					{textInput}
-				</Box>
-				<Box
-					role="button"
-					aria-label={tSearch('searchByTitleOrText')}
-					onClick={() => query.trim() && navigate('home', { hledat: query.trim() })}
-					sx={{ width: 48, height: 48, borderRadius: 1.5, background: gradient, color: 'common.white', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, boxShadow: 2 }}
-				>
-					<ArrowForwardRounded />
-				</Box>
-			</Box>
-		)
-	}
+	// Grey square search field, no button — the variants tune the DROP
+	// SHADOW / elevation so the field pops and pulls attention.
+	const shadow = {
+		// 1 — soft: subtle lift
+		1: '0px 2px 6px rgba(0,0,0,0.10)',
+		// 2 — medium: clearly elevated (default)
+		2: '0px 4px 14px rgba(0,0,0,0.15)',
+		// 3 — strong: prominent float
+		3: '0px 8px 22px rgba(0,0,0,0.20)',
+		// 4 — brand glow: primary-tinted shadow draws the eye
+		4: `0px 6px 18px ${alpha(theme.palette.primary.main, 0.4)}`,
+		// 5 — floating: detached grey field over a transparent bar (see wrapper)
+		5: '0px 10px 26px rgba(0,0,0,0.22)',
+	}[variant]
+
+	// variant 5 detaches the field: the wrapper below goes transparent so
+	// the grey field floats above the tab bar as its own elevated element
+	const floatingField = variant === 5
+
+	const squareField = () => (
+		<Box
+			component="form"
+			onSubmit={submitSearch}
+			sx={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 1,
+				bgcolor: 'grey.100',
+				borderRadius: 2.5,
+				paddingX: 2,
+				paddingY: 1.75,
+				boxShadow: shadow,
+			}}
+		>
+			{plainIcon}
+			{textInput}
+		</Box>
+	)
 
 	return (
 		<Box
@@ -364,7 +342,7 @@ function DemoMobilePage() {
 					{recentSection}
 				</Box>
 
-				{/* ===== SEARCH: full-width square bar connected to the tab bar ===== */}
+				{/* ===== SEARCH: grey elevated field above the tab bar ===== */}
 				<Box
 					sx={{
 						position: 'fixed',
@@ -373,12 +351,18 @@ function DemoMobilePage() {
 						transform: 'translateX(-50%)',
 						width: '100%',
 						maxWidth: PAGE_MAX_WIDTH,
-						bgcolor: alpha(theme.palette.background.paper, 0.85),
-						backdropFilter: 'blur(12px)',
-						borderTop: '1px solid',
-						borderColor: 'grey.200',
-						paddingX: 2.5,
-						paddingY: 1.25,
+						// floating variant: transparent so the field detaches;
+						// others: a connected blurred bar joined to the tab bar
+						...(floatingField
+							? { paddingX: 2.5, paddingBottom: 1.5 }
+							: {
+									bgcolor: alpha(theme.palette.background.paper, 0.85),
+									backdropFilter: 'blur(12px)',
+									borderTop: '1px solid',
+									borderColor: 'grey.200',
+									paddingX: 2.5,
+									paddingY: 1.25,
+							  }),
 						boxSizing: 'border-box',
 						zIndex: 10,
 					}}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -45,14 +45,15 @@ type DemoVariant = 1 | 2 | 3 | 4
 /**
  * Grey canvas + white cards for the picks; the recent section is the quiet
  * airy list (subtle M1 look). The SEARCH is buttonless with a primary
- * gradient border (desktop MainSearchInput look). A WHITE hero zone wraps the
- * header + the "some idea" label and ends just past it, so the white cards
- * below read as floating on the grey canvas. Variants tune that white zone:
+ * gradient border (desktop MainSearchInput look). The top of the page is a
+ * soft WHITE → grey wash that reaches down INTO the (intact) picks section and
+ * fades out behind the cards — no hard line dividing the section. Variants
+ * tune how deep the white reaches and how gentle the fade is:
  *
- * 1 — straight edge, ends just past the label (default)
- * 2 — rounded bottom corners (sheet look)
- * 3 — extends further down, toward the first card
- * 4 — straight edge with a soft drop shadow under the white zone
+ * 1 — fades out behind the first card (default)
+ * 2 — reaches deeper, fades behind the second card
+ * 3 — shorter, whiter — ends higher, just into the first card
+ * 4 — very soft, long wash over the whole top
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -128,19 +129,20 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	// ---- picks: label lives in the white hero, cards float on grey ---
+	// ---- picks: one section (label + cards) as before ----------------
 
-	const picksLabel = <Box sx={{ paddingX: 2.5 }}>{label(tHome('recommended.idea'), browseAction)}</Box>
-
-	const picksCards = (
-		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
-			{loading
-				? Array.from({ length: 4 }).map((_, i) => (
-						<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
-				  ))
-				: rec.slice(0, 5).map((s) => (
-						<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1 }} />
-				  ))}
+	const picks = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+			{label(tHome('recommended.idea'), browseAction)}
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+				{loading
+					? Array.from({ length: 4 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
+					  ))
+					: rec.slice(0, 5).map((s) => (
+							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1 }} />
+					  ))}
+			</Box>
 		</Box>
 	)
 
@@ -220,27 +222,15 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// ---- white hero zone: wraps the header + label, ends past it ------
+	// ---- white → grey wash: reaches into the picks section, no hard line
 
-	const heroRounded = variant === 2 // rounded bottom corners (sheet look)
-	const heroPadBottom = variant === 3 ? 3 : 1.5 // 3 = white extends further down
-	const heroShadow = variant === 4 // soft drop shadow under the white zone
-
-	const hero = (
-		<Box
-			sx={{
-				bgcolor: 'background.paper',
-				paddingBottom: heroPadBottom,
-				...(heroRounded && { borderBottomLeftRadius: 4, borderBottomRightRadius: 4 }),
-				...(heroShadow && { boxShadow: '0 6px 14px rgba(0,0,0,0.06)' }),
-				position: 'relative',
-				zIndex: 1,
-			}}
-		>
-			{header}
-			<Box sx={{ paddingTop: 1 }}>{picksLabel}</Box>
-		</Box>
-	)
+	const heroWhite = theme.palette.common.white
+	const heroGrey = theme.palette.grey[100]
+	// how deep the white reaches (px) + where the fade begins/ends (%)
+	const bgHeight = variant === 2 ? 360 : variant === 3 ? 220 : variant === 4 ? 400 : 280
+	const solidStop = variant === 4 ? 25 : variant === 3 ? 55 : variant === 2 ? 45 : 50
+	const greyStop = variant === 3 ? 92 : variant === 4 ? 100 : variant === 2 ? 85 : 80
+	const heroBg = `linear-gradient(to bottom, ${heroWhite} 0%, ${heroWhite} ${solidStop}%, ${heroGrey} ${greyStop}%)`
 
 	return (
 		<Box
@@ -268,10 +258,25 @@ function DemoMobilePage() {
 					position: 'relative',
 				}}
 			>
-				{hero}
-				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 1.5, paddingBottom: CONTENT_CLEARANCE }}>
-					{picksCards}
-					{recent}
+				{/* white → grey wash behind the top; fades out inside the picks section */}
+				<Box
+					sx={{
+						position: 'absolute',
+						top: 0,
+						left: 0,
+						right: 0,
+						height: `calc(env(safe-area-inset-top) + ${bgHeight}px)`,
+						background: heroBg,
+						zIndex: 0,
+						pointerEvents: 'none',
+					}}
+				/>
+				<Box sx={{ position: 'relative', zIndex: 1 }}>
+					{header}
+					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2, paddingBottom: CONTENT_CLEARANCE }}>
+						{picks}
+						{recent}
+					</Box>
 				</Box>
 
 				{/* ===== SEARCH: floating above the tab bar (thumb zone) ===== */}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -47,7 +47,7 @@ export default SmartPage(DemoMobilePage, [
 const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const TAB_BAR_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
-const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 156px)'
+const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
 type DemoVariant = 1 | 2 | 3 | 4
 
@@ -593,12 +593,12 @@ function DemoMobilePage() {
 					<Box
 						sx={{
 							position: 'fixed',
-							bottom: 'calc(env(safe-area-inset-bottom) + 72px)',
+							bottom: 'calc(env(safe-area-inset-bottom) + 82px)',
 							left: '50%',
 							transform: 'translateX(-50%)',
 							width: '100%',
 							maxWidth: PAGE_MAX_WIDTH,
-							paddingX: 2,
+							paddingX: 2.5,
 							zIndex: 10,
 						}}
 					>

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -3,7 +3,15 @@
 import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
-import { Box, Clickable, Divider, Image, Typography, useTheme } from '@/common/ui'
+import {
+	Box,
+	Button,
+	Clickable,
+	Divider,
+	Image,
+	Typography,
+	useTheme,
+} from '@/common/ui'
 import { Link } from '@/common/ui/Link/Link'
 import { alpha } from '@/common/ui/mui'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
@@ -15,15 +23,17 @@ import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { getAssetUrl } from '@/tech/paths.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
+	AutoAwesomeRounded,
 	HomeRounded,
 	LoginRounded,
 	MusicNoteRounded,
 	PersonOutlineRounded,
 	QueueMusicRounded,
+	ScheduleRounded,
 	SearchRounded,
 } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
-import { Fragment, useState } from 'react'
+import { Fragment, ReactNode, useState } from 'react'
 import { BasicVariantPack } from '../../../api/dtos'
 
 export default SmartPage(DemoMobilePage, [
@@ -40,6 +50,19 @@ const BOTTOM_NAV_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
 
 type DemoVariant = 1 | 2 | 3
 
+/**
+ * Three internally consistent design systems, all sharing the same page
+ * anatomy (header → search → sections → CTA → tab bar). The rule everywhere:
+ * saturated color is reserved for the two focus elements (search, CTA) and
+ * the active tab; content sections stay calm and uniform.
+ *
+ * 1 — cards on grey: grey canvas, every section is the same white card,
+ *     search pops via gradient border + shadow
+ * 2 — gradient hero: search lives inside the brand header, sections are
+ *     identical grey panels on white
+ * 3 — blue system: white canvas, one accent (primary), tonal panels and
+ *     icon-badged section headers, M3-style tab pills
+ */
 function DemoMobilePage() {
 	const theme = useTheme()
 	const tHome = useTranslations('home')
@@ -57,6 +80,19 @@ function DemoMobilePage() {
 	const lastAdded = useLastAddedSongs()
 
 	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
+	const primaryTint = alpha(theme.palette.primary.main, 0.06)
+
+	// Section content panels — identical within each variant
+	const panelBg =
+		variant === 1
+			? 'background.paper'
+			: variant === 2
+			? 'grey.100'
+			: primaryTint
+	const panelShadow = variant === 1 ? 1 : 0
+	const rowsHaveDividers = variant === 1
+	const rowBg = variant === 1 ? 'transparent' : 'background.paper'
+	const tileBg = variant === 1 ? 'grey.100' : 'background.paper'
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
@@ -65,9 +101,11 @@ function DemoMobilePage() {
 		}
 	}
 
-	const searchField = (
+	const searchInner = (
 		<>
-			<SearchRounded sx={{ color: 'grey.600' }} />
+			<SearchRounded
+				sx={{ color: variant === 3 ? 'primary.main' : 'grey.600' }}
+			/>
 			<TextField
 				value={query}
 				onChange={setQuery}
@@ -106,16 +144,131 @@ function DemoMobilePage() {
 		/>
 	)
 
-	const carouselTile = (s: BasicVariantPack, tileBg: string) => (
+	const heroTexts = (leadColor?: string) => (
+		<Box>
+			<Typography small color={leadColor} sx={leadColor ? {} : { opacity: 0.85 }}>
+				{tHome('hero.lead')}
+			</Typography>
+			<Typography variant="h3" strong={800}>
+				{tHome('hero.title')}
+			</Typography>
+		</Box>
+	)
+
+	const browseAction = (
+		<Clickable>
+			<Link to="songsList" params={{ s: undefined }}>
+				<Typography small strong uppercase color="primary.main">
+					{tHome('allList.browse')}
+				</Typography>
+			</Link>
+		</Clickable>
+	)
+
+	const sectionBadge = (icon: ReactNode) => (
+		<Box
+			sx={{
+				width: 28,
+				height: 28,
+				borderRadius: 1.5,
+				bgcolor: alpha(theme.palette.primary.main, 0.12),
+				color: 'primary.main',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+			}}
+		>
+			{icon}
+		</Box>
+	)
+
+	// Shared section anatomy: header (title + optional action) + content panel
+	const Section = ({
+		title,
+		icon,
+		action,
+		children,
+	}: {
+		title: string
+		icon: ReactNode
+		action?: ReactNode
+		children: ReactNode
+	}) => {
+		const header = (
+			<Box
+				sx={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					gap: 1,
+				}}
+			>
+				<Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+					{variant === 3 && sectionBadge(icon)}
+					<Typography variant="h6" strong>
+						{title}
+					</Typography>
+				</Box>
+				{action}
+			</Box>
+		)
+
+		if (variant === 3) {
+			return (
+				<Box
+					sx={{
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 1,
+						paddingX: 2.5,
+					}}
+				>
+					{header}
+					<Box
+						sx={{
+							bgcolor: panelBg,
+							borderRadius: 3,
+							padding: 1.5,
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 1,
+						}}
+					>
+						{children}
+					</Box>
+				</Box>
+			)
+		}
+
+		return (
+			<Box sx={{ paddingX: 2.5 }}>
+				<Box
+					sx={{
+						bgcolor: panelBg,
+						borderRadius: 3,
+						boxShadow: panelShadow,
+						padding: 2,
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 1.5,
+					}}
+				>
+					{header}
+					{children}
+				</Box>
+			</Box>
+		)
+	}
+
+	const carouselTile = (s: BasicVariantPack) => (
 		<Clickable key={s.packGuid}>
 			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
 				<Box
 					sx={{
-						width: 168,
+						width: 156,
 						bgcolor: tileBg,
-						borderRadius: 3,
-						padding: 2,
-						boxShadow: 1,
+						borderRadius: 2,
+						padding: 1.5,
 						scrollSnapAlign: 'start',
 						display: 'flex',
 						flexDirection: 'column',
@@ -124,9 +277,9 @@ function DemoMobilePage() {
 				>
 					<Box
 						sx={{
-							width: 36,
-							height: 36,
-							borderRadius: 2,
+							width: 32,
+							height: 32,
+							borderRadius: 1.5,
 							bgcolor: alpha(theme.palette.primary.main, 0.12),
 							color: 'primary.main',
 							display: 'flex',
@@ -149,24 +302,19 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const carouselSkeletons = Array.from({ length: 4 }).map((_, i) => (
-		<Skeleton
-			key={i}
-			variant="rounded"
-			sx={{
-				minWidth: 168,
-				height: 120,
-				borderRadius: 3,
-				bgcolor: 'grey.200',
-			}}
-		/>
-	))
-
 	const listSkeletons = Array.from({ length: 4 }).map((_, i) => (
 		<Skeleton
 			key={i}
 			variant="rounded"
-			sx={{ height: 64, borderRadius: 2, bgcolor: 'grey.200' }}
+			sx={{ height: 60, borderRadius: 2, bgcolor: 'grey.200' }}
+		/>
+	))
+
+	const carouselSkeletons = Array.from({ length: 3 }).map((_, i) => (
+		<Skeleton
+			key={i}
+			variant="rounded"
+			sx={{ minWidth: 156, height: 112, borderRadius: 2, bgcolor: 'grey.200' }}
 		/>
 	))
 
@@ -179,7 +327,7 @@ function DemoMobilePage() {
 				minWidth: '100%',
 				marginTop: `calc(-1 * ${TOOLBAR_SPACER})`,
 				minHeight: '100dvh',
-				bgcolor: variant === 2 ? 'grey.200' : 'grey.300',
+				bgcolor: 'grey.300',
 				display: 'flex',
 				justifyContent: 'center',
 			}}
@@ -190,89 +338,75 @@ function DemoMobilePage() {
 					maxWidth: PAGE_MAX_WIDTH,
 					minWidth: 0,
 					minHeight: '100dvh',
-					bgcolor:
-						variant === 1 ? 'grey.100' : variant === 2 ? 'background.paper' : 'background.paper',
+					bgcolor: variant === 1 ? 'grey.100' : 'background.paper',
 					display: 'flex',
 					flexDirection: 'column',
 					boxShadow: 3,
 				}}
 			>
-				{/* ===================== HEADER ===================== */}
-				{variant === 1 && (
-					<>
+				{/* ===================== HEADER + SEARCH ===================== */}
+				{variant === 2 ? (
+					<Box
+						sx={{
+							background: gradient,
+							color: 'common.white',
+							paddingX: 2.5,
+							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
+							paddingBottom: 3.5,
+							borderRadius: '0 0 28px 28px',
+							position: 'relative',
+							overflow: 'hidden',
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 2.5,
+						}}
+					>
 						<Box
 							sx={{
-								background: gradient,
-								color: 'common.white',
-								paddingX: 2.5,
-								paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-								paddingBottom: 8,
-								position: 'relative',
-								overflow: 'hidden',
+								position: 'absolute',
+								right: 16,
+								top: 'calc(env(safe-area-inset-top) + 52px)',
+								pointerEvents: 'none',
+								opacity: 0.95,
 							}}
 						>
-							<Box
-								sx={{
-									position: 'absolute',
-									right: 12,
-									bottom: -6,
-									transform: 'rotate(-8deg)',
-									pointerEvents: 'none',
-									opacity: 0.9,
-								}}
-							>
-								{sheep(76)}
-							</Box>
-							<Box
-								sx={{
-									display: 'flex',
-									justifyContent: 'space-between',
-									alignItems: 'start',
-								}}
-							>
-								<Box>
-									<Typography small sx={{ opacity: 0.85 }}>
-										{tHome('hero.lead')}
-									</Typography>
-									<Typography variant="h4" strong={800}>
-										{tHome('hero.title')}
-									</Typography>
-								</Box>
-								{loginLink('common.white')}
-							</Box>
+							{sheep(72)}
 						</Box>
-
+						<Box
+							sx={{
+								display: 'flex',
+								justifyContent: 'space-between',
+								alignItems: 'start',
+							}}
+						>
+							{heroTexts()}
+							{loginLink('common.white')}
+						</Box>
 						<Box
 							component="form"
 							onSubmit={submitSearch}
 							sx={{
-								marginTop: -3.5,
-								marginX: 2.5,
-								position: 'relative',
-								zIndex: 1,
 								display: 'flex',
 								alignItems: 'center',
 								gap: 1,
 								bgcolor: 'background.paper',
-								borderRadius: 3,
+								borderRadius: 10,
 								paddingX: 2,
 								paddingY: 1.5,
 								boxShadow: 2,
 							}}
 						>
-							{searchField}
+							{searchInner}
 						</Box>
-					</>
-				)}
-
-				{variant === 2 && (
+					</Box>
+				) : (
 					<Box
 						sx={{
 							paddingX: 2.5,
 							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
 							display: 'flex',
 							flexDirection: 'column',
-							gap: 2,
+							gap: 2.5,
 						}}
 					>
 						<Box
@@ -282,276 +416,203 @@ function DemoMobilePage() {
 								alignItems: 'end',
 							}}
 						>
-							<Box>
-								<Typography small color="grey.700">
-									{tHome('hero.lead')}
-								</Typography>
-								<Typography variant="h3" strong={800}>
-									{tHome('hero.title')}
-								</Typography>
-							</Box>
+							{heroTexts('grey.700')}
 							{loginLink('primary.main')}
 						</Box>
 
-						<Box
-							component="form"
-							onSubmit={submitSearch}
-							sx={{
-								display: 'flex',
-								alignItems: 'center',
-								gap: 1,
-								bgcolor: 'grey.100',
-								borderRadius: 10,
-								paddingX: 2,
-								paddingY: 1.25,
-							}}
-						>
-							{searchField}
-						</Box>
+						{variant === 1 ? (
+							// gradient border + shadow make the search the strongest element
+							<Box
+								sx={{
+									background: gradient,
+									padding: '2px',
+									borderRadius: 10,
+									boxShadow: 3,
+								}}
+							>
+								<Box
+									component="form"
+									onSubmit={submitSearch}
+									sx={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: 1,
+										bgcolor: 'background.paper',
+										borderRadius: 10,
+										paddingX: 2,
+										paddingY: 1.5,
+									}}
+								>
+									{searchInner}
+								</Box>
+							</Box>
+						) : (
+							// tonal filled field — the only saturated icon on the page
+							<Box
+								component="form"
+								onSubmit={submitSearch}
+								sx={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: 1,
+									bgcolor: alpha(theme.palette.primary.main, 0.08),
+									borderRadius: 10,
+									paddingX: 2,
+									paddingY: 1.5,
+								}}
+							>
+								{searchInner}
+							</Box>
+						)}
 					</Box>
 				)}
 
-				{variant === 3 && (
-					<Box
-						sx={{
-							bgcolor: 'primary.main',
-							color: 'common.white',
-							paddingX: 2.5,
-							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-							paddingBottom: 3,
-							borderRadius: '0 0 28px 28px',
-							position: 'relative',
-							overflow: 'hidden',
-							display: 'flex',
-							flexDirection: 'column',
-							gap: 2,
-						}}
-					>
-						<Box
-							sx={{
-								position: 'absolute',
-								right: 10,
-								top: 'calc(env(safe-area-inset-top) + 10px)',
-								pointerEvents: 'none',
-							}}
-						>
-							{sheep(64)}
-						</Box>
-						<Box>
-							<Typography small sx={{ opacity: 0.85 }}>
-								{tHome('hero.lead')}
-							</Typography>
-							<Typography variant="h4" strong={800}>
-								{tHome('hero.title')}
-							</Typography>
-						</Box>
-						<Box
-							component="form"
-							onSubmit={submitSearch}
-							sx={{
-								display: 'flex',
-								alignItems: 'center',
-								gap: 1,
-								bgcolor: 'background.paper',
-								borderRadius: 10,
-								paddingX: 2,
-								paddingY: 1.25,
-							}}
-						>
-							{searchField}
-						</Box>
-					</Box>
-				)}
-
-				{/* ===================== CONTENT ===================== */}
+				{/* ===================== SECTIONS ===================== */}
 				<Box
 					sx={{
 						flex: 1,
 						display: 'flex',
 						flexDirection: 'column',
-						gap: 3,
-						paddingTop: 3,
+						gap: 2.5,
+						paddingTop: 2.5,
 						paddingBottom: BOTTOM_NAV_CLEARANCE,
 					}}
 				>
-					{/* --- Recommended songs --- */}
-					<Box
-						sx={{
-							display: 'flex',
-							flexDirection: 'column',
-							gap: 1,
-							paddingX: 2.5,
-						}}
+					<Section
+						title={tHome('recommended.idea')}
+						icon={<AutoAwesomeRounded sx={{ fontSize: 18 }} />}
 					>
-						<Typography variant="h6" strong>
-							{tHome('recommended.idea')}
-						</Typography>
-
-						{variant === 2 ? (
-							<Box
-								sx={{
-									bgcolor: 'grey.100',
-									borderRadius: 3,
-									overflow: 'hidden',
-									display: 'flex',
-									flexDirection: 'column',
-								}}
-							>
-								{recommended.isLoading
-									? listSkeletons
-									: recommended.data.slice(0, 4).map((v, i, arr) => (
-											<Fragment key={v.packGuid}>
-												<SongVariantCard
-													data={v}
-													dense
-													sx={{ bgcolor: 'transparent', borderRadius: 0 }}
-												/>
-												{i < arr.length - 1 && (
-													<Divider sx={{ marginX: 2 }} />
-												)}
-											</Fragment>
-									  ))}
-							</Box>
-						) : (
-							<Box
-								sx={{
-									...(variant === 3 && {
-										bgcolor: alpha(theme.palette.primary.main, 0.07),
-										borderRadius: 3,
-										padding: 1.5,
-									}),
-									display: 'flex',
-									flexDirection: 'column',
-									gap: 1,
-								}}
-							>
-								{recommended.isLoading
-									? listSkeletons
-									: recommended.data.slice(0, 4).map((v) => (
+						<Box sx={{ display: 'flex', flexDirection: 'column', gap: rowsHaveDividers ? 0 : 1 }}>
+							{recommended.isLoading
+								? listSkeletons
+								: recommended.data.slice(0, 4).map((s, i, arr) => (
+										<Fragment key={s.packGuid}>
 											<SongVariantCard
-												key={v.packGuid}
-												data={v}
+												data={s}
 												dense
 												sx={{
-													bgcolor: 'background.paper',
-													boxShadow: 1,
+													bgcolor: rowBg,
+													borderRadius: rowsHaveDividers ? 0 : 2,
 												}}
 											/>
-									  ))}
-							</Box>
-						)}
-					</Box>
+											{rowsHaveDividers && i < arr.length - 1 && (
+												<Divider sx={{ marginX: 1 }} />
+											)}
+										</Fragment>
+								  ))}
+						</Box>
+					</Section>
 
-					{/* --- Last added (horizontal carousel) --- */}
-					<Box
-						sx={{
-							display: 'flex',
-							flexDirection: 'column',
-							gap: 1,
-							// full-bleed grey band separates the section from the white page
-							...(variant === 2 && {
-								bgcolor: 'grey.100',
-								paddingY: 2,
-							}),
-						}}
+					<Section
+						title={tHome('lastAdded.title')}
+						icon={<ScheduleRounded sx={{ fontSize: 18 }} />}
+						action={browseAction}
 					>
-						<Typography variant="h6" strong sx={{ paddingX: 2.5 }}>
-							{tHome('lastAdded.title')}
-						</Typography>
-
 						<Box
 							sx={{
-								...(variant === 3 && {
-									bgcolor: alpha(theme.palette.secondary.main, 0.14),
-									borderRadius: 3,
-									marginX: 2.5,
-									paddingX: 1.5,
-								}),
+								display: 'flex',
+								gap: 1,
+								overflowX: 'auto',
+								// bleed the scroll area to the panel edges
+								marginX: variant === 3 ? -1.5 : -2,
+								paddingX: variant === 3 ? 1.5 : 2,
+								scrollSnapType: 'x mandatory',
+								'&::-webkit-scrollbar': { display: 'none' },
 							}}
 						>
+							{lastAdded.isLoading
+								? carouselSkeletons
+								: lastAdded.data.slice(0, 8).map((s) => carouselTile(s))}
+						</Box>
+					</Section>
+
+					{/* ===================== CTA ===================== */}
+					{variant === 3 ? (
+						<Box sx={{ paddingX: 2.5 }}>
 							<Box
 								sx={{
+									bgcolor: panelBg,
+									borderRadius: 3,
+									padding: 2.5,
 									display: 'flex',
+									flexDirection: 'column',
 									gap: 1.5,
-									overflowX: 'auto',
-									paddingX: variant === 3 ? 0 : 2.5,
-									paddingY: variant === 3 ? 1.5 : 1,
-									scrollSnapType: 'x mandatory',
-									'&::-webkit-scrollbar': { display: 'none' },
+									position: 'relative',
 								}}
 							>
-								{lastAdded.isLoading
-									? carouselSkeletons
-									: lastAdded.data
-											.slice(0, 8)
-											.map((s) => carouselTile(s, 'background.paper'))}
-							</Box>
-						</Box>
-					</Box>
-
-					{/* --- CTA: browse all songs --- */}
-					{
-						<Box
-							sx={{
-								marginX: 2.5,
-								...(variant === 1
-									? {
-											bgcolor: 'background.paper',
-											boxShadow: 1,
-									  }
-									: {
-											background: gradient,
-											color: 'common.white',
-									  }),
-								borderRadius: 3,
-								padding: 2.5,
-								display: 'flex',
-								flexDirection: 'column',
-								gap: 1.5,
-							}}
-						>
-							<Box>
-								<Typography variant="h6" strong>
-									{tSuggestions('noIdea')}
-								</Typography>
-								<Typography
-									small
-									color={variant === 1 ? 'grey.700' : undefined}
-									sx={variant === 1 ? {} : { opacity: 0.9 }}
+								<Box
+									sx={{
+										position: 'absolute',
+										top: -34,
+										right: 12,
+										pointerEvents: 'none',
+									}}
 								>
-									{tSuggestions('chooseSuggestion')}
-								</Typography>
+									{sheep(56)}
+								</Box>
+								<Box>
+									<Typography variant="h6" strong>
+										{tSuggestions('noIdea')}
+									</Typography>
+									<Typography small color="grey.700">
+										{tSuggestions('chooseSuggestion')}
+									</Typography>
+								</Box>
+								<Button
+									to="songsList"
+									toParams={{ s: undefined }}
+									size="large"
+									startIcon={<QueueMusicRounded />}
+								>
+									{tHome('allList.title')}
+								</Button>
 							</Box>
-							<Clickable>
-								<Link to="songsList" params={{ s: undefined }}>
-									<Box
-										sx={{
-											...(variant === 1
-												? {
-														background: gradient,
-														color: 'common.white',
-												  }
-												: {
-														bgcolor: 'background.paper',
-														color: 'primary.main',
-												  }),
-											borderRadius: 2,
-											paddingY: 1.5,
-											display: 'flex',
-											alignItems: 'center',
-											justifyContent: 'center',
-											gap: 1,
-										}}
-									>
-										<QueueMusicRounded fontSize="small" />
-										<Typography small strong uppercase>
-											{tHome('allList.title')}
-										</Typography>
-									</Box>
-								</Link>
-							</Clickable>
 						</Box>
-					}
+					) : (
+						<Box sx={{ paddingX: 2.5 }}>
+							<Box
+								sx={{
+									background: gradient,
+									color: 'common.white',
+									borderRadius: 3,
+									padding: 2.5,
+									display: 'flex',
+									flexDirection: 'column',
+									gap: 1.5,
+								}}
+							>
+								<Box>
+									<Typography variant="h6" strong>
+										{tSuggestions('noIdea')}
+									</Typography>
+									<Typography small sx={{ opacity: 0.9 }}>
+										{tSuggestions('chooseSuggestion')}
+									</Typography>
+								</Box>
+								<Clickable>
+									<Link to="songsList" params={{ s: undefined }}>
+										<Box
+											sx={{
+												bgcolor: 'background.paper',
+												color: 'primary.main',
+												borderRadius: 2,
+												paddingY: 1.5,
+												display: 'flex',
+												alignItems: 'center',
+												justifyContent: 'center',
+												gap: 1,
+											}}
+										>
+											<QueueMusicRounded fontSize="small" />
+											<Typography small strong uppercase>
+												{tHome('allList.title')}
+											</Typography>
+										</Box>
+									</Link>
+								</Clickable>
+							</Box>
+						</Box>
+					)}
 				</Box>
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -47,17 +47,17 @@ const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
 type DemoVariant = 1 | 2 | 3 | 4
-type SectionStyle = 'card' | 'band' | 'outline' | 'plain'
+type SectionStyle = 'band' | 'gap' | 'tint' | 'strip'
 
 /**
- * One base design (gradient header, docked search in the thumb zone,
- * translucent tab bar, no CTA card) with four section-separation styles:
+ * One base design (square gradient header, docked search in the thumb
+ * zone, translucent tab bar, no CTA card). Sections are always full-bleed
+ * — four takes on separating them by background:
  *
- * 1 — card: white cards with a soft shadow on a grey canvas (baseline)
- * 2 — band: full-bleed alternating background bands, edge-to-edge rows
- * 3 — outline: flat white cards with a hairline border, no shadow
- * 4 — plain: white canvas, sections separated by whitespace + full-width
- *     hairline dividers only
+ * 1 — band: alternating grey/white background bands (baseline)
+ * 2 — gap: white bands separated by thick grey spacer strips
+ * 3 — tint: the recommended band gets a soft brand tint, the rest white
+ * 4 — strip: iOS plain-table style — grey label strips over white content
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -79,16 +79,10 @@ function DemoMobilePage() {
 	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
 
 	const sectionStyle: SectionStyle = (
-		['card', 'band', 'outline', 'plain'] as const
+		['band', 'gap', 'tint', 'strip'] as const
 	)[variant - 1]
 
-	const canvasBg =
-		sectionStyle === 'card' || sectionStyle === 'outline'
-			? 'grey.100'
-			: 'background.paper'
-	// tiles must contrast with the surface they sit on
-	const tileBg = (sectionBg: 'white' | 'grey') =>
-		sectionBg === 'white' ? 'grey.100' : 'background.paper'
+	const canvasBg = sectionStyle === 'gap' ? 'grey.200' : 'background.paper'
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
@@ -180,49 +174,49 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	// Section wrapper — the separation style is the experiment here
+	// Section wrapper — full-bleed surfaces, the separation is the experiment
 	const Section = ({
 		title,
 		action,
-		bandBg,
+		surface,
 		children,
 	}: {
 		title: string
 		action?: ReactNode
-		/** band style only: which full-bleed background this section gets */
-		bandBg?: 'white' | 'grey'
+		/** which full-bleed background this section gets */
+		surface: 'white' | 'grey' | 'tint'
 		children: ReactNode
 	}) => {
-		if (sectionStyle === 'band') {
-			return (
-				<Box
-					sx={{
-						bgcolor: bandBg === 'grey' ? 'grey.100' : 'background.paper',
-						paddingY: 2.5,
-						paddingX: 2.5,
-						display: 'flex',
-						flexDirection: 'column',
-						gap: 1.5,
-					}}
-				>
-					{sectionLabel(title, action)}
-					{children}
-				</Box>
-			)
-		}
+		const surfaceBg =
+			surface === 'grey'
+				? 'grey.100'
+				: surface === 'tint'
+				? alpha(theme.palette.primary.main, 0.06)
+				: 'background.paper'
 
-		if (sectionStyle === 'plain') {
+		if (sectionStyle === 'strip') {
 			return (
-				<Box
-					sx={{
-						paddingX: 2.5,
-						display: 'flex',
-						flexDirection: 'column',
-						gap: 1.5,
-					}}
-				>
-					{sectionLabel(title, action)}
-					{children}
+				<Box>
+					<Box
+						sx={{
+							bgcolor: 'grey.100',
+							paddingY: 1,
+							paddingX: 3,
+						}}
+					>
+						{sectionLabel(title, action)}
+					</Box>
+					<Box
+						sx={{
+							paddingX: 2.5,
+							paddingY: 2,
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 1.5,
+						}}
+					>
+						{children}
+					</Box>
 				</Box>
 			)
 		}
@@ -230,28 +224,16 @@ function DemoMobilePage() {
 		return (
 			<Box
 				sx={{
+					bgcolor: sectionStyle === 'gap' ? 'background.paper' : surfaceBg,
+					paddingY: 2.5,
 					paddingX: 2.5,
 					display: 'flex',
 					flexDirection: 'column',
-					gap: 1,
+					gap: 1.5,
 				}}
 			>
 				{sectionLabel(title, action)}
-				<Box
-					sx={{
-						bgcolor: 'background.paper',
-						borderRadius: 3,
-						...(sectionStyle === 'card'
-							? { boxShadow: 1 }
-							: { border: '1px solid', borderColor: 'grey.300' }),
-						padding: 2,
-						display: 'flex',
-						flexDirection: 'column',
-						gap: 2,
-					}}
-				>
-					{children}
-				</Box>
+				{children}
 			</Box>
 		)
 	}
@@ -315,8 +297,8 @@ function DemoMobilePage() {
 		/>
 	))
 
-	// carousel bleeds to the section edge; the inset depends on the wrapper
-	const carouselBleed = sectionStyle === 'band' || sectionStyle === 'plain' ? 2.5 : 2
+	// carousel bleeds to the section edge; the inset matches its padding
+	const carouselBleed = 2.5
 
 	const recommendedRows = (
 		<Box sx={{ display: 'flex', flexDirection: 'column' }}>
@@ -398,7 +380,6 @@ function DemoMobilePage() {
 						alignItems: 'end',
 						background: gradient,
 						color: 'common.white',
-						borderRadius: sectionStyle === 'band' ? 0 : '0 0 28px 28px',
 					}}
 				>
 					<Box>
@@ -418,30 +399,31 @@ function DemoMobilePage() {
 						flex: 1,
 						display: 'flex',
 						flexDirection: 'column',
-						gap:
-							sectionStyle === 'band' ? 0 : sectionStyle === 'plain' ? 3 : 2.5,
-						paddingTop: sectionStyle === 'band' ? 0 : 2.5,
+						// gap style: the grey canvas shows through as spacer strips
+						gap: sectionStyle === 'gap' ? 1.5 : 0,
+						paddingTop: sectionStyle === 'gap' ? 1.5 : 0,
 						paddingBottom: DOCKED_SEARCH_CLEARANCE,
 					}}
 				>
-					<Section title={tHome('recommended.idea')} bandBg="grey">
+					<Section
+						title={tHome('recommended.idea')}
+						surface={
+							sectionStyle === 'band'
+								? 'grey'
+								: sectionStyle === 'tint'
+								? 'tint'
+								: 'white'
+						}
+					>
 						{recommendedRows}
 					</Section>
-
-					{sectionStyle === 'plain' && <Divider />}
 
 					<Section
 						title={tHome('lastAdded.title')}
 						action={browseAction}
-						bandBg="white"
+						surface="white"
 					>
-						{lastAddedCarousel(
-							sectionStyle === 'card' || sectionStyle === 'outline'
-								? 'grey.100'
-								: sectionStyle === 'band'
-								? tileBg('white')
-								: tileBg('white')
-						)}
+						{lastAddedCarousel('grey.100')}
 					</Section>
 				</Box>
 

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -13,6 +13,7 @@ import { useSmartParams } from '@/routes/useSmartParams'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
+	ArrowForwardRounded,
 	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
@@ -39,19 +40,25 @@ export default SmartPage(DemoMobilePage, [
 
 const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
-const DOCKED_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 172px)'
 
-type DemoVariant = 1 | 2 | 3 | 4
+// bottom layout metrics (kept in sync so nothing hides / crowds)
+const TAB_BAR = 'calc(env(safe-area-inset-bottom) + 64px)'
+const FLOAT_SEARCH_BOTTOM = 'calc(env(safe-area-inset-bottom) + 88px)'
+const FLOAT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 188px)'
+const CONNECTED_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 148px)'
+
+type DemoVariant = 1 | 2 | 3 | 4 | 5
 
 /**
- * One fixed recipe: docked search at the bottom, a CLEAN recommended list
- * ("Nějaký nápad") and a COLORFUL "Poslední přidané" section. The variants
- * differ only in how colorful the last-added section is:
+ * The picked C2 recipe (clean two-line picks + colorful recent rows),
+ * cleaned up with consistent spacing. The variants only change the SEARCH
+ * bar treatment:
  *
- * 1 — carousel: horizontal square gradient cover tiles
- * 2 — thumb rows: colorful thumbnail rows (two-line clean recommended)
- * 3 — grid: colorful two-column gradient tiles
- * 4 — wide cards: horizontal wide gradient cards with title + first line
+ * 1 — gradient pill: floating rounded pill with brand gradient border
+ * 2 — filled pill: floating soft grey pill (subtle)
+ * 3 — connected bar: full-width field attached directly above the tab bar
+ * 4 — compose: floating field + circular gradient submit button
+ * 5 — outlined pill: floating white pill with a thin primary border
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -64,9 +71,8 @@ function DemoMobilePage() {
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	// colorful thumbnail rows (2) is the picked default
 	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 2
+		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 1
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
@@ -74,7 +80,6 @@ function DemoMobilePage() {
 	const p = theme.palette
 	const gradient = `linear-gradient(135deg, ${p.primary.main}, ${p.primary.dark})`
 
-	// deterministic "cover art" gradients derived from palette tokens
 	const artGradients = [
 		`linear-gradient(135deg, ${p.primary.main}, ${p.primary.dark})`,
 		`linear-gradient(135deg, ${p.info.main}, ${p.primary.main})`,
@@ -106,30 +111,10 @@ function DemoMobilePage() {
 	const last = lastAdded.data
 	const loading = recommended.isLoading || lastAdded.isLoading
 
-	const twoLineRecommended = variant === 2
+	const isConnected = variant === 3
+	const contentClearance = isConnected ? CONNECTED_CLEARANCE : FLOAT_CLEARANCE
 
-	// ---- shared bits -------------------------------------------------
-
-	const searchPill = (
-		<Box sx={{ background: gradient, padding: '2px', borderRadius: 10, boxShadow: 3 }}>
-			<Box
-				component="form"
-				onSubmit={submitSearch}
-				sx={{
-					display: 'flex',
-					alignItems: 'center',
-					gap: 1,
-					bgcolor: 'background.paper',
-					borderRadius: 10,
-					paddingX: 2,
-					paddingY: 1.5,
-				}}
-			>
-				<SearchRounded sx={{ color: 'grey.600' }} />
-				<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
-			</Box>
-		</Box>
-	)
+	// ---- header ------------------------------------------------------
 
 	const header = (
 		<Box
@@ -137,6 +122,7 @@ function DemoMobilePage() {
 				paddingX: 2.5,
 				// clear the device status bar (time/battery) + breathing room
 				paddingTop: 'calc(env(safe-area-inset-top) + 32px)',
+				paddingBottom: 0.5,
 				display: 'flex',
 				justifyContent: 'space-between',
 				alignItems: 'end',
@@ -191,11 +177,11 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const artThumb = (i: number, size: number) => (
+	const artThumb = (i: number) => (
 		<Box
 			sx={{
-				width: size,
-				height: size,
+				width: 46,
+				height: 46,
 				borderRadius: 2,
 				background: artFor(i),
 				color: 'common.white',
@@ -209,30 +195,29 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// ---- CLEAN recommended list (white, no color) --------------------
+	// ---- body sections (consistent geometry) -------------------------
 
-	const cleanRecommended = (
-		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+	// clean two-line picks — no color, hairline dividers
+	const recommendedSection = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
 			{label(tHome('recommended.idea'), browseAction)}
 			<Box sx={{ display: 'flex', flexDirection: 'column' }}>
 				{loading
 					? Array.from({ length: 5 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ height: twoLineRecommended ? 52 : 40, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
+							<Skeleton key={i} variant="rounded" sx={{ height: 52, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
 					  ))
 					: rec.slice(0, 5).map((s, i, arr) => (
 							<Fragment key={s.packGuid}>
 								<Clickable>
 									<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: twoLineRecommended ? 1.25 : 1.5 }}>
+										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25 }}>
 											<Box sx={{ minWidth: 0, flex: 1 }}>
 												<Typography strong noWrap>
 													{s.title}
 												</Typography>
-												{twoLineRecommended && (
-													<Typography small color="grey.700" noWrap>
-														{firstLine(s.sheetData)}
-													</Typography>
-												)}
+												<Typography small color="grey.700" noWrap>
+													{firstLine(s.sheetData)}
+												</Typography>
 											</Box>
 											<ChevronRightRounded sx={{ color: 'grey.400' }} />
 										</Box>
@@ -245,76 +230,21 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// ---- COLORFUL last-added section (four treatments) ---------------
-
-	const lastLabel = (
-		<Box sx={{ paddingX: 2.5 }}>{label(tHome('lastAdded.title'))}</Box>
-	)
-
-	// (1) horizontal square cover tiles
-	const lastCarousel = (
-		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-			{lastLabel}
-			<Box
-				sx={{
-					display: 'flex',
-					gap: 1.5,
-					overflowX: 'auto',
-					paddingX: 2.5,
-					paddingBottom: 0.5,
-					scrollSnapType: 'x mandatory',
-					'&::-webkit-scrollbar': { display: 'none' },
-				}}
-			>
-				{loading
-					? Array.from({ length: 4 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ minWidth: 128, height: 160, borderRadius: 3, bgcolor: 'grey.200' }} />
-					  ))
-					: last.slice(0, 8).map((s, i) => (
-							<Clickable key={s.packGuid}>
-								<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-									<Box sx={{ width: 128, display: 'flex', flexDirection: 'column', gap: 1 }}>
-										<Box
-											sx={{
-												width: 128,
-												height: 128,
-												borderRadius: 3,
-												background: artFor(i),
-												color: 'common.white',
-												display: 'flex',
-												alignItems: 'flex-end',
-												padding: 1.25,
-												boxShadow: 1,
-											}}
-										>
-											<MusicNoteRounded />
-										</Box>
-										<Typography strong noWrap sx={{ paddingX: 0.5 }}>
-											{s.title}
-										</Typography>
-									</Box>
-								</Link>
-							</Clickable>
-					  ))}
-			</Box>
-		</Box>
-	)
-
-	// (2) colorful thumbnail rows
-	const lastThumbRows = (
-		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+	// colorful recent — thumbnail rows, same row rhythm as above
+	const recentSection = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
 			{label(tHome('lastAdded.title'))}
 			<Box sx={{ display: 'flex', flexDirection: 'column' }}>
 				{loading
-					? Array.from({ length: 4 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
+					? Array.from({ length: 5 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ height: 58, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
 					  ))
 					: last.slice(0, 5).map((s, i, arr) => (
 							<Fragment key={s.packGuid}>
 								<Clickable>
 									<Link to="variant" params={parseVariantAlias(s.packAlias)}>
 										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1 }}>
-											{artThumb(i, 44)}
+											{artThumb(i)}
 											<Typography strong noWrap sx={{ flex: 1 }}>
 												{s.title}
 											</Typography>
@@ -334,102 +264,114 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// (3) colorful two-column gradient tiles
-	const lastGrid = (
-		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-			{label(tHome('lastAdded.title'))}
-			<Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5 }}>
-				{loading
-					? Array.from({ length: 4 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ height: 110, borderRadius: 3, bgcolor: 'grey.200' }} />
-					  ))
-					: last.slice(0, 6).map((s, i) => (
-							<Clickable key={s.packGuid}>
-								<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-									<Box
-										sx={{
-											height: 110,
-											borderRadius: 3,
-											background: artFor(i),
-											color: 'common.white',
-											padding: 1.5,
-											display: 'flex',
-											flexDirection: 'column',
-											justifyContent: 'space-between',
-											boxShadow: 1,
-										}}
-									>
-										<MusicNoteRounded fontSize="small" />
-										<Typography strong noWrap>
-											{s.title}
-										</Typography>
-									</Box>
-								</Link>
-							</Clickable>
-					  ))}
+	// ---- search treatments -------------------------------------------
+
+	const fieldInner = (
+		<>
+			<SearchRounded sx={{ color: 'grey.600' }} />
+			<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
+		</>
+	)
+
+	// 1 — gradient-border pill
+	const gradientPill = (
+		<Box sx={{ background: gradient, padding: '2px', borderRadius: 10, boxShadow: 3 }}>
+			<Box
+				component="form"
+				onSubmit={submitSearch}
+				sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'background.paper', borderRadius: 10, paddingX: 2, paddingY: 1.5 }}
+			>
+				{fieldInner}
 			</Box>
 		</Box>
 	)
 
-	// (4) horizontal wide gradient cards
-	const lastWideCards = (
-		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-			{lastLabel}
+	// 2 — soft filled pill
+	const filledPill = (
+		<Box
+			component="form"
+			onSubmit={submitSearch}
+			sx={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 1,
+				bgcolor: 'grey.100',
+				borderRadius: 10,
+				paddingX: 2,
+				paddingY: 1.75,
+				boxShadow: 2,
+			}}
+		>
+			{fieldInner}
+		</Box>
+	)
+
+	// 4 — filled field + circular gradient submit
+	const composeBar = (
+		<Box component="form" onSubmit={submitSearch} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
 			<Box
 				sx={{
+					flex: 1,
 					display: 'flex',
-					gap: 1.5,
-					overflowX: 'auto',
-					paddingX: 2.5,
-					paddingBottom: 0.5,
-					scrollSnapType: 'x mandatory',
-					'&::-webkit-scrollbar': { display: 'none' },
+					alignItems: 'center',
+					gap: 1,
+					bgcolor: 'background.paper',
+					border: '1px solid',
+					borderColor: 'grey.300',
+					borderRadius: 10,
+					paddingX: 2,
+					paddingY: 1.5,
+					boxShadow: 2,
 				}}
 			>
-				{loading
-					? Array.from({ length: 3 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ minWidth: 260, height: 104, borderRadius: 3, bgcolor: 'grey.200' }} />
-					  ))
-					: last.slice(0, 8).map((s, i) => (
-							<Clickable key={s.packGuid}>
-								<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-									<Box
-										sx={{
-											width: 260,
-											height: 104,
-											borderRadius: 3,
-											background: artFor(i),
-											color: 'common.white',
-											padding: 2,
-											display: 'flex',
-											flexDirection: 'column',
-											justifyContent: 'space-between',
-											boxShadow: 1,
-											scrollSnapAlign: 'start',
-										}}
-									>
-										<Typography strong noWrap>
-											{s.title}
-										</Typography>
-										<Typography small noWrap sx={{ opacity: 0.9 }}>
-											{firstLine(s.sheetData)}
-										</Typography>
-									</Box>
-								</Link>
-							</Clickable>
-					  ))}
+				{fieldInner}
+			</Box>
+			<Box
+				role="button"
+				aria-label={tSearch('searchByTitleOrText')}
+				onClick={() => query.trim() && navigate('home', { hledat: query.trim() })}
+				sx={{
+					width: 48,
+					height: 48,
+					borderRadius: 10,
+					background: gradient,
+					color: 'common.white',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					flexShrink: 0,
+					boxShadow: 3,
+				}}
+			>
+				<ArrowForwardRounded />
 			</Box>
 		</Box>
 	)
 
-	const lastSection =
-		variant === 1
-			? lastCarousel
-			: variant === 2
-			? lastThumbRows
-			: variant === 3
-			? lastGrid
-			: lastWideCards
+	// 5 — outlined white pill
+	const outlinedPill = (
+		<Box
+			component="form"
+			onSubmit={submitSearch}
+			sx={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 1,
+				bgcolor: 'background.paper',
+				border: '1.5px solid',
+				borderColor: 'primary.main',
+				borderRadius: 10,
+				paddingX: 2,
+				paddingY: 1.5,
+				boxShadow: 1,
+			}}
+		>
+			{fieldInner}
+		</Box>
+	)
+
+	const floatingSearch =
+		variant === 1 ? gradientPill : variant === 2 ? filledPill : variant === 4 ? composeBar : outlinedPill
 
 	return (
 		<Box
@@ -459,13 +401,59 @@ function DemoMobilePage() {
 				}}
 			>
 				{header}
-				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: DOCKED_CLEARANCE }}>
-					{cleanRecommended}
-					{lastSection}
+				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: contentClearance }}>
+					{recommendedSection}
+					{recentSection}
 				</Box>
 
-				{/* ===== Docked search — floats above the tab bar (thumb zone) ===== */}
-				<DockedSearch>{searchPill}</DockedSearch>
+				{/* ===== SEARCH: floating pill above the tab bar (thumb zone) ===== */}
+				{!isConnected && (
+					<Box
+						sx={{
+							position: 'fixed',
+							bottom: FLOAT_SEARCH_BOTTOM,
+							left: '50%',
+							transform: 'translateX(-50%)',
+							width: '100%',
+							maxWidth: PAGE_MAX_WIDTH,
+							paddingX: 4,
+							boxSizing: 'border-box',
+							zIndex: 10,
+						}}
+					>
+						{floatingSearch}
+					</Box>
+				)}
+
+				{/* ===== SEARCH: full-width bar connected to the tab bar ===== */}
+				{isConnected && (
+					<Box
+						sx={{
+							position: 'fixed',
+							bottom: TAB_BAR,
+							left: '50%',
+							transform: 'translateX(-50%)',
+							width: '100%',
+							maxWidth: PAGE_MAX_WIDTH,
+							bgcolor: alpha(theme.palette.background.paper, 0.85),
+							backdropFilter: 'blur(12px)',
+							borderTop: '1px solid',
+							borderColor: 'grey.200',
+							paddingX: 2.5,
+							paddingY: 1.25,
+							boxSizing: 'border-box',
+							zIndex: 10,
+						}}
+					>
+						<Box
+							component="form"
+							onSubmit={submitSearch}
+							sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'grey.100', borderRadius: 3, paddingX: 2, paddingY: 1.25 }}
+						>
+							{fieldInner}
+						</Box>
+					</Box>
+				)}
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}
 				<Box
@@ -496,27 +484,6 @@ function DemoMobilePage() {
 					</Link>
 				</Box>
 			</Box>
-		</Box>
-	)
-}
-
-/** Fixed pill floating above the tab bar (thumb zone). */
-function DockedSearch({ children }: { children: ReactNode }) {
-	return (
-		<Box
-			sx={{
-				position: 'fixed',
-				bottom: 'calc(env(safe-area-inset-bottom) + 82px)',
-				left: '50%',
-				transform: 'translateX(-50%)',
-				width: '100%',
-				maxWidth: PAGE_MAX_WIDTH,
-				paddingX: 4,
-				boxSizing: 'border-box',
-				zIndex: 10,
-			}}
-		>
-			{children}
 		</Box>
 	)
 }

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -64,8 +64,9 @@ function DemoMobilePage() {
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
+	// colorful thumbnail rows (2) is the picked default
 	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 1
+		parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 2
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
@@ -131,7 +132,16 @@ function DemoMobilePage() {
 	)
 
 	const header = (
-		<Box sx={{ paddingX: 2.5, paddingTop: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
+		<Box
+			sx={{
+				paddingX: 2.5,
+				// clear the device status bar (time/battery) + breathing room
+				paddingTop: 'calc(env(safe-area-inset-top) + 32px)',
+				display: 'flex',
+				justifyContent: 'space-between',
+				alignItems: 'end',
+			}}
+		>
 			<Box>
 				<Typography small color="grey.700">
 					{tHome('hero.lead')}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -1,17 +1,19 @@
 'use client'
 
+import AllListPanel from '@/app/components/components/AllListPanel/AllListPanel'
+import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
+import MainSearchInput from '@/app/components/components/MainSearchInput'
+import RecommendedSongsList from '@/app/components/components/RecommendedSongsList/RecommendedSongsList'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
-import { Box, Clickable, Divider, Typography, useTheme } from '@/common/ui'
+import RowSongPackCard from '@/common/components/song/RowSongPackCard'
+import { Box, Clickable, Typography, useTheme } from '@/common/ui'
 import { alpha } from '@/common/ui/mui'
 import { Link } from '@/common/ui/Link/Link'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
-import { TextField } from '@/common/ui/TextField'
-import { useSmartNavigate } from '@/routes/useSmartNavigate'
+import { SongVariantCard } from '@/common/ui/SongCard'
 import { useSmartParams } from '@/routes/useSmartParams'
-import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
-	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
 	LibraryMusicOutlined,
@@ -19,11 +21,9 @@ import {
 	LoginRounded,
 	PersonOutlineRounded,
 	PersonRounded,
-	SearchRounded,
 } from '@mui/icons-material'
-import { Sheet } from '@pepavlin/sheet-api'
 import { useTranslations } from 'next-intl'
-import { Fragment, ReactNode, useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 export default SmartPage(DemoMobilePage, [
 	'hideToolbar',
@@ -35,23 +35,22 @@ export default SmartPage(DemoMobilePage, [
 
 const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
-
-// bottom layout metrics (kept in sync so nothing hides / crowds)
 const TAB_BAR = 'calc(env(safe-area-inset-bottom) + 64px)'
-const CONNECTED_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 148px)'
+const CONTENT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 176px)'
 
 type DemoVariant = 1 | 2 | 3 | 4 | 5
 
 /**
- * The picked recipe (clean two-line picks + colorful recent rows) with a
- * grey square search field, no button. The variants only tune the field's
- * DROP SHADOW / elevation so it pops and pulls attention:
+ * The agreed mobile layout (greeting header, picks + recent sections,
+ * docked search, tab bar) but built from the REAL desktop components so it
+ * feels like the same app. Variants differ in which desktop components /
+ * densities are used:
  *
- * 1 — soft: subtle lift
- * 2 — medium: clearly elevated (default)
- * 3 — strong: prominent float
- * 4 — brand glow: primary-tinted shadow
- * 5 — floating: detached grey field over a transparent bar
+ * 1 — dense song cards (SongVariantCard dense) + recent pills, desktop search
+ * 2 — full song cards (SongVariantCard) + recent pills, desktop search
+ * 3 — the actual RecommendedSongsList + AllListPanel + recent pills
+ * 4 — song cards for both picks and recent (uniform), grey elevated search
+ * 5 — dense cards + recent pills, desktop search with the gradient border
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -59,41 +58,18 @@ function DemoMobilePage() {
 	const tNav = useTranslations('navigation')
 	const tSearch = useTranslations('search')
 
-	const navigate = useSmartNavigate()
 	const [query, setQuery] = useState('')
+
+	const recommended = useRecommendedSongs()
+	const lastAdded = useLastAddedSongs()
+
+	const rec = recommended.data
+	const last = lastAdded.data
+	const loading = recommended.isLoading || lastAdded.isLoading
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	// soft-square connected search (2) is the closest to the picked look
-	const variant: DemoVariant =
-		parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 2
-
-	const recommended = useRecommendedSongs()
-
-	const submitSearch = (e: React.FormEvent) => {
-		e.preventDefault()
-		if (query.trim().length > 0) navigate('home', { hledat: query.trim() })
-	}
-
-	const firstLine = (sheetData: string) => {
-		try {
-			return (
-				new Sheet(sheetData)
-					.getSections()[0]
-					?.text?.split('\n')
-					.find((l) => l.trim().length > 0) ?? ''
-			)
-		} catch {
-			return ''
-		}
-	}
-
-	const rec = recommended.data
-	const loading = recommended.isLoading
-
-	// all variants use the connected square search bar; they differ only in
-	// the field's corner sharpness / fill / accent
-	const contentClearance = CONNECTED_CLEARANCE
+	const variant: DemoVariant = parsed >= 1 && parsed <= 5 ? (parsed as DemoVariant) : 1
 
 	// ---- header ------------------------------------------------------
 
@@ -101,7 +77,6 @@ function DemoMobilePage() {
 		<Box
 			sx={{
 				paddingX: 2.5,
-				// clear the device status bar (time/battery) + breathing room
 				paddingTop: 'calc(env(safe-area-inset-top) + 32px)',
 				paddingBottom: 0.5,
 				display: 'flex',
@@ -121,16 +96,7 @@ function DemoMobilePage() {
 				<Link to="login" params={{ previousPage: '', message: '' }}>
 					<Box
 						aria-label={tNav('login')}
-						sx={{
-							width: 42,
-							height: 42,
-							borderRadius: 10,
-							bgcolor: 'grey.100',
-							color: 'primary.main',
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-						}}
+						sx={{ width: 42, height: 42, borderRadius: 10, bgcolor: 'grey.100', color: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
 					>
 						<LoginRounded fontSize="small" />
 					</Box>
@@ -158,93 +124,103 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
+	const cardSkeletons = (n: number, h: number) =>
+		Array.from({ length: n }).map((_, i) => (
+			<Skeleton key={i} variant="rounded" sx={{ height: h, borderRadius: 2, bgcolor: 'grey.200' }} />
+		))
 
-	// ---- body sections (consistent geometry) -------------------------
+	// ---- picks section (desktop song cards) --------------------------
 
-	// clean two-line picks — no color, hairline dividers
-	const recommendedSection = (
+	const picksCards = (dense: boolean) => (
 		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
 			{label(tHome('recommended.idea'), browseAction)}
-			<Box sx={{ display: 'flex', flexDirection: 'column' }}>
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
 				{loading
-					? Array.from({ length: 5 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ height: 52, borderRadius: 2, bgcolor: 'grey.200', mb: 1 }} />
-					  ))
-					: rec.slice(0, 5).map((s, i, arr) => (
-							<Fragment key={s.packGuid}>
-								<Clickable>
-									<Link to="variant" params={parseVariantAlias(s.packAlias)}>
-										<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25 }}>
-											<Box sx={{ minWidth: 0, flex: 1 }}>
-												<Typography strong noWrap>
-													{s.title}
-												</Typography>
-												<Typography small color="grey.700" noWrap>
-													{firstLine(s.sheetData)}
-												</Typography>
-											</Box>
-											<ChevronRightRounded sx={{ color: 'grey.400' }} />
-										</Box>
-									</Link>
-								</Clickable>
-								{i < arr.length - 1 && <Divider />}
-							</Fragment>
+					? cardSkeletons(4, dense ? 56 : 120)
+					: rec.slice(0, dense ? 5 : 4).map((s) => (
+							<SongVariantCard key={s.packGuid} data={s} dense={dense} sx={{ boxShadow: 1 }} />
 					  ))}
 			</Box>
 		</Box>
 	)
 
-	// ---- search treatments -------------------------------------------
-
-	const textInput = (
-		<TextField value={query} onChange={setQuery} placeholder={tSearch('searchByTitleOrText')} />
-	)
-	const plainIcon = <SearchRounded sx={{ color: 'grey.600' }} />
-
-	// Grey square search field, no button — the variants tune the DROP
-	// SHADOW / elevation so the field pops and pulls attention.
-	const shadow = {
-		// 1 — soft: subtle lift
-		1: '0px 2px 6px rgba(0,0,0,0.10)',
-		// 2 — medium: clearly elevated (default)
-		2: '0px 4px 14px rgba(0,0,0,0.15)',
-		// 3 — strong: prominent float
-		3: '0px 8px 22px rgba(0,0,0,0.20)',
-		// 4 — brand glow: primary-tinted shadow draws the eye
-		4: `0px 6px 18px ${alpha(theme.palette.primary.main, 0.4)}`,
-		// 5 — floating: detached grey field over a transparent bar (see wrapper)
-		5: '0px 10px 26px rgba(0,0,0,0.22)',
-	}[variant]
-
-	// variant 5 detaches the field: the wrapper below goes transparent so
-	// the grey field floats above the tab bar as its own elevated element
-	const floatingField = variant === 5
-
-	const squareField = () => (
-		<Box
-			component="form"
-			onSubmit={submitSearch}
-			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				gap: 1,
-				bgcolor: 'grey.100',
-				borderRadius: 2.5,
-				paddingX: 2,
-				paddingY: 1.75,
-				boxShadow: shadow,
-			}}
-		>
-			{plainIcon}
-			{textInput}
+	// the actual desktop RecommendedSongsList component
+	const picksComponent = (
+		<Box sx={{ paddingX: 1 }}>
+			<RecommendedSongsList listType="list" dense />
 		</Box>
 	)
+
+	// ---- recent section ----------------------------------------------
+
+	// desktop RowSongPackCard pills
+	const recentPills = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+			{label(tHome('lastAdded.title'))}
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+				{loading ? cardSkeletons(4, 48) : last.slice(0, 5).map((s) => <RowSongPackCard key={s.packGuid} data={s} />)}
+			</Box>
+		</Box>
+	)
+
+	// desktop song cards for recent too (uniform look)
+	const recentCards = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+			{label(tHome('lastAdded.title'))}
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+				{loading
+					? cardSkeletons(4, 56)
+					: last.slice(0, 5).map((s) => (
+							<SongVariantCard key={s.packGuid} data={s} dense properties={['SHOW_PUBLISHED_DATE']} sx={{ boxShadow: 1 }} />
+					  ))}
+			</Box>
+		</Box>
+	)
+
+	// ---- search: the real desktop MainSearchInput --------------------
+
+	const desktopSearch = (gradientBorder: boolean) => (
+		<MainSearchInput gradientBorder={gradientBorder} value={query} onChange={setQuery} autoFocus={false} />
+	)
+
+	// ---- compose body + search per variant ---------------------------
+
+	const body =
+		variant === 1 ? (
+			<>
+				{picksCards(true)}
+				{recentPills}
+			</>
+		) : variant === 2 ? (
+			<>
+				{picksCards(false)}
+				{recentPills}
+			</>
+		) : variant === 3 ? (
+			<>
+				{picksComponent}
+				{recentPills}
+				<Box sx={{ paddingX: 2.5 }}>
+					<AllListPanel />
+				</Box>
+			</>
+		) : variant === 4 ? (
+			<>
+				{picksCards(true)}
+				{recentCards}
+			</>
+		) : (
+			<>
+				{picksCards(true)}
+				{recentPills}
+			</>
+		)
+
+	const search = desktopSearch(variant === 5)
 
 	return (
 		<Box
 			sx={{
-				// width 0 + minWidth 100% stops the column's maxWidth from
-				// propagating as min-content through the flex app layout
 				width: 0,
 				minWidth: '100%',
 				marginTop: `calc(-1 * ${TOOLBAR_SPACER})`,
@@ -268,11 +244,11 @@ function DemoMobilePage() {
 				}}
 			>
 				{header}
-				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: contentClearance }}>
-					{recommendedSection}
+				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2.5, paddingBottom: CONTENT_CLEARANCE }}>
+					{body}
 				</Box>
 
-				{/* ===== SEARCH: grey elevated field above the tab bar ===== */}
+				{/* ===== SEARCH: floating above the tab bar (thumb zone) ===== */}
 				<Box
 					sx={{
 						position: 'fixed',
@@ -281,23 +257,13 @@ function DemoMobilePage() {
 						transform: 'translateX(-50%)',
 						width: '100%',
 						maxWidth: PAGE_MAX_WIDTH,
-						// floating variant: transparent so the field detaches;
-						// others: a connected blurred bar joined to the tab bar
-						...(floatingField
-							? { paddingX: 2.5, paddingBottom: 1.5 }
-							: {
-									bgcolor: alpha(theme.palette.background.paper, 0.85),
-									backdropFilter: 'blur(12px)',
-									borderTop: '1px solid',
-									borderColor: 'grey.200',
-									paddingX: 2.5,
-									paddingY: 1.25,
-							  }),
+						paddingX: 2.5,
+						paddingBottom: 1.5,
 						boxSizing: 'border-box',
 						zIndex: 10,
 					}}
 				>
-					{squareField()}
+					{search}
 				</Box>
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}
@@ -318,7 +284,7 @@ function DemoMobilePage() {
 						zIndex: 10,
 					}}
 				>
-					<Link to="demoMobile" params={{ v }} style={{ flex: 1 }}>
+					<Link to="demoMobile" params={{ v: undefined }} style={{ flex: 1 }}>
 						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active />
 					</Link>
 					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
@@ -342,16 +308,7 @@ type TabItemProps = {
 
 function TabItem({ icon, activeIcon, label, active }: TabItemProps) {
 	return (
-		<Box
-			sx={{
-				display: 'flex',
-				flexDirection: 'column',
-				alignItems: 'center',
-				gap: 0.25,
-				paddingY: 1,
-				color: active ? 'primary.main' : 'grey.700',
-			}}
-		>
+		<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, paddingY: 1, color: active ? 'primary.main' : 'grey.700' }}>
 			{active ? activeIcon ?? icon : icon}
 			<Typography small strong={active ? 700 : 400}>
 				{label}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -4,14 +4,16 @@ import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/ho
 import MainSearchInput from '@/app/components/components/MainSearchInput'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { SmartPage } from '@/common/components/app/SmartPage/SmartPage'
-import RowSongPackCard from '@/common/components/song/RowSongPackCard'
-import { Box, Clickable, Typography, useTheme } from '@/common/ui'
+import { Box, Clickable, Divider, Typography, useTheme } from '@/common/ui'
 import { alpha } from '@/common/ui/mui'
 import { Link } from '@/common/ui/Link/Link'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
 import { SongVariantCard } from '@/common/ui/SongCard'
 import { useSmartParams } from '@/routes/useSmartParams'
+import { getSmartDateAgoString } from '@/tech/date/date.tech'
+import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
+	ChevronRightRounded,
 	HomeOutlined,
 	HomeRounded,
 	LibraryMusicOutlined,
@@ -21,7 +23,7 @@ import {
 	PersonRounded,
 } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
-import { ReactNode, useState } from 'react'
+import { Fragment, ReactNode, useState } from 'react'
 
 export default SmartPage(DemoMobilePage, [
 	'hideToolbar',
@@ -39,14 +41,14 @@ const CONTENT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 176px)'
 type DemoVariant = 1 | 2 | 3 | 4
 
 /**
- * The D1 layout (desktop song cards + recent pills + desktop search), made
- * less flat purely with GREY hierarchy — no new colors. Variants tune the
- * shades/depth so surfaces read apart:
+ * Grey canvas + white cards for the picks (the liked G3 look). The recent
+ * section is kept deliberately QUIET so it recedes below the picks —
+ * variants only change how subtle it is:
  *
- * 1 — bordered: white page, white cards with a hairline border, grey pills
- * 2 — elevated: white page, white cards lifted by a soft shadow, grey pills
- * 3 — grouped: light-grey canvas, white cards for both sections (iOS-like)
- * 4 — banded: white page, bordered cards, recent on a full-width grey band
+ * 1 — quiet rows: transparent rows with hairline dividers
+ * 2 — airy list: spaced rows, muted, no dividers or chevrons
+ * 3 — chips: small bordered title chips that wrap
+ * 4 — flat cards: white cards but flat (no lift) so they sit quietly
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -63,20 +65,7 @@ function DemoMobilePage() {
 
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
-	const variant: DemoVariant = parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 2
-
-	// grey palette per variant — the only thing that changes
-	const greyCanvas = variant === 3
-	const pageBg = greyCanvas ? 'grey.100' : 'background.paper'
-
-	// recent shows white cards on a grey surface in the grouped/banded looks
-	const recentWhiteCards = variant === 3 || variant === 4
-
-	// white song card that lifts off the surface via border and/or shadow
-	const cardSx =
-		variant === 1 || variant === 4
-			? { bgcolor: 'background.paper', border: '1px solid', borderColor: 'grey.200', boxShadow: 'none' as const }
-			: { bgcolor: 'background.paper', boxShadow: 1 }
+	const variant: DemoVariant = parsed >= 1 && parsed <= 4 ? (parsed as DemoVariant) : 1
 
 	// ---- header ------------------------------------------------------
 
@@ -103,7 +92,7 @@ function DemoMobilePage() {
 				<Link to="login" params={{ previousPage: '', message: '' }}>
 					<Box
 						aria-label={tNav('login')}
-						sx={{ width: 42, height: 42, borderRadius: 10, bgcolor: greyCanvas ? 'background.paper' : 'grey.100', color: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: greyCanvas ? 1 : 0 }}
+						sx={{ width: 42, height: 42, borderRadius: 10, bgcolor: 'background.paper', color: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: 1 }}
 					>
 						<LoginRounded fontSize="small" />
 					</Box>
@@ -131,50 +120,98 @@ function DemoMobilePage() {
 		</Clickable>
 	)
 
-	const skeletons = (n: number, h: number) =>
-		Array.from({ length: n }).map((_, i) => (
-			<Skeleton key={i} variant="rounded" sx={{ height: h, borderRadius: 2, bgcolor: greyCanvas ? 'grey.200' : 'grey.100' }} />
-		))
-
-	// ---- picks: dense white song cards -------------------------------
+	// ---- picks: white cards on the grey canvas -----------------------
 
 	const picks = (
 		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
 			{label(tHome('recommended.idea'), browseAction)}
 			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
 				{loading
-					? skeletons(4, 56)
-					: rec.slice(0, 5).map((s) => <SongVariantCard key={s.packGuid} data={s} dense sx={cardSx} />)}
+					? Array.from({ length: 4 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
+					  ))
+					: rec.slice(0, 5).map((s) => (
+							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1 }} />
+					  ))}
 			</Box>
 		</Box>
 	)
 
-	// ---- recent: grey pills (or white cards in the grouped variant) --
+	// ---- recent: kept quiet so it recedes ----------------------------
+
+	const dateOf = (publishedAt?: Date | null) => (publishedAt ? getSmartDateAgoString(publishedAt) : '')
+
+	const recentInner = (() => {
+		if (loading) {
+			return Array.from({ length: 4 }).map((_, i) => (
+				<Skeleton key={i} variant="rounded" sx={{ height: 32, borderRadius: 1, bgcolor: 'grey.200' }} />
+			))
+		}
+
+		// 3 — subtle bordered title chips
+		if (variant === 3) {
+			return (
+				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+					{last.slice(0, 6).map((s) => (
+						<Clickable key={s.packGuid}>
+							<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+								<Box sx={{ border: '1px solid', borderColor: 'grey.300', borderRadius: 10, paddingX: 1.75, paddingY: 0.75 }}>
+									<Typography small color="grey.700" noWrap>
+										{s.title}
+									</Typography>
+								</Box>
+							</Link>
+						</Clickable>
+					))}
+				</Box>
+			)
+		}
+
+		// 4 — flat white cards (no lift) so they sit quietly under the picks
+		if (variant === 4) {
+			return (
+				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+					{last.slice(0, 5).map((s) => (
+						<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper' }} />
+					))}
+				</Box>
+			)
+		}
+
+		// 1 & 2 — quiet transparent rows (1 with dividers, 2 airy)
+		const airy = variant === 2
+		return (
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: airy ? 0.5 : 0 }}>
+				{last.slice(0, 5).map((s, i, arr) => (
+					<Fragment key={s.packGuid}>
+						<Clickable>
+							<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+								<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: airy ? 1 : 1.25 }}>
+									<Typography color="grey.800" noWrap sx={{ flex: 1 }}>
+										{s.title}
+									</Typography>
+									<Typography small color="grey.500" noWrap>
+										{dateOf(s.publishedAt)}
+									</Typography>
+									{!airy && <ChevronRightRounded sx={{ color: 'grey.400' }} />}
+								</Box>
+							</Link>
+						</Clickable>
+						{!airy && i < arr.length - 1 && <Divider />}
+					</Fragment>
+				))}
+			</Box>
+		)
+	})()
 
 	const recent = (
-		<Box
-			sx={{
-				display: 'flex',
-				flexDirection: 'column',
-				gap: 1.5,
-				// banded variant puts recent on a full-width grey strip
-				...(variant === 4 && { bgcolor: 'grey.100', paddingY: 2.5 }),
-			}}
-		>
-			<Box sx={{ paddingX: 2.5 }}>{label(tHome('lastAdded.title'))}</Box>
-			<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
-				{loading
-					? skeletons(4, 48)
-					: recentWhiteCards
-					? last.slice(0, 5).map((s) => (
-							<SongVariantCard key={s.packGuid} data={s} dense properties={['SHOW_PUBLISHED_DATE']} sx={cardSx} />
-					  ))
-					: last.slice(0, 5).map((s) => <RowSongPackCard key={s.packGuid} data={s} />)}
-			</Box>
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+			{label(tHome('lastAdded.title'))}
+			{recentInner}
 		</Box>
 	)
 
-	// ---- search: the real desktop MainSearchInput --------------------
+	// ---- search ------------------------------------------------------
 
 	const search = (
 		<MainSearchInput gradientBorder={false} value={query} onChange={setQuery} autoFocus={false} />
@@ -198,7 +235,8 @@ function DemoMobilePage() {
 					maxWidth: PAGE_MAX_WIDTH,
 					minWidth: 0,
 					minHeight: '100dvh',
-					bgcolor: pageBg,
+					// the grey canvas that white cards float on
+					bgcolor: 'grey.100',
 					display: 'flex',
 					flexDirection: 'column',
 					boxShadow: 3,

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -46,26 +46,24 @@ export default SmartPage(DemoMobilePage, [
 
 const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
-const BOTTOM_NAV_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
+const TAB_BAR_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 84px)'
+const DOCKED_SEARCH_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 156px)'
 
-type DemoVariant = 1 | 2 | 3 | 4 | 5
+type DemoVariant = 1 | 2 | 3 | 4
 
 /**
- * Three internally consistent design systems, all sharing the same page
- * anatomy (header → search → sections → CTA → tab bar). The rule everywhere:
- * saturated color is reserved for the two focus elements (search, CTA) and
- * the active tab; content sections stay calm and uniform.
+ * Variants — all share the "cards" language, they differ in where the
+ * search lives and in the accent system:
  *
- * 1 — cards on grey: grey canvas, every section is the same white card,
- *     search pops via gradient border + shadow
- * 2 — gradient hero: search lives inside the brand header, sections are
- *     identical grey panels on white
- * 3 — blue system: white canvas, one accent (primary), tonal panels and
- *     icon-badged section headers, M3-style tab pills
- *
- * Thumb-reach experiments (no last-added section, search within thumb zone):
- * 4 — centered search: hero pushes the search to mid-screen
- * 5 — docked search: search floats just above the bottom tab bar
+ * 1 — search top (baseline): grey canvas, white section cards, gradient
+ *     border makes the search the strongest element
+ * 2 — search docked at the very bottom above the tab bar (thumb zone),
+ *     otherwise identical to 1
+ * 3 — search mid-screen: hero fills the upper half, trimmed content
+ *     below (no last-added), otherwise the style of 1
+ * 4 — polished blue system: white canvas, neutral grey panels, blue used
+ *     only as accent (badges, actions, button, tab pill); search docked
+ *     bottom with a solid blue border
  */
 function DemoMobilePage() {
 	const theme = useTheme()
@@ -80,28 +78,26 @@ function DemoMobilePage() {
 	const { v } = useSmartParams('demoMobile')
 	const parsed = Number(v)
 	const variant: DemoVariant =
-		parsed === 2 || parsed === 3 || parsed === 4 || parsed === 5
-			? (parsed as DemoVariant)
-			: 1
+		parsed === 2 || parsed === 3 || parsed === 4 ? (parsed as DemoVariant) : 1
 
 	const recommended = useRecommendedSongs()
 	const lastAdded = useLastAddedSongs()
 
 	const gradient = `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`
-	const primaryTint = alpha(theme.palette.primary.main, 0.06)
 
-	// Section content panels — identical within each variant
-	const panelBg =
-		variant === 1
-			? 'background.paper'
-			: variant === 3
-			? primaryTint
-			: 'grey.100'
-	const panelShadow = variant === 1 ? 1 : 0
-	const rowsHaveDividers = variant === 1
-	const rowBg = variant === 1 ? 'transparent' : 'background.paper'
-	const tileBg = variant === 1 ? 'grey.100' : 'background.paper'
-	const showLastAdded = variant <= 3
+	const blueSystem = variant === 4
+	const searchDocked = variant === 2 || variant === 4
+	const searchCentered = variant === 3
+	const showLastAdded = !searchCentered
+
+	// One card language per variant: v1–v3 white cards on grey canvas,
+	// v4 neutral grey panels on white canvas with blue accents only
+	const canvasBg = blueSystem ? 'background.paper' : 'grey.100'
+	const panelBg = blueSystem ? 'grey.100' : 'background.paper'
+	const panelShadow = blueSystem ? 0 : 1
+	const rowsHaveDividers = !blueSystem
+	const rowBg = blueSystem ? 'background.paper' : 'transparent'
+	const tileBg = blueSystem ? 'background.paper' : 'grey.100'
 
 	const submitSearch = (e: React.FormEvent) => {
 		e.preventDefault()
@@ -113,7 +109,7 @@ function DemoMobilePage() {
 	const searchInner = (
 		<>
 			<SearchRounded
-				sx={{ color: variant === 3 ? 'primary.main' : 'grey.600' }}
+				sx={{ color: blueSystem ? 'primary.main' : 'grey.600' }}
 			/>
 			<TextField
 				value={query}
@@ -123,8 +119,28 @@ function DemoMobilePage() {
 		</>
 	)
 
-	// gradient border + shadow make the search the strongest element
-	const gradientSearchForm = (
+	// v1–v3: gradient border + shadow make the search the strongest element
+	// v4: solid blue border keeps the single-accent system
+	const searchForm = blueSystem ? (
+		<Box
+			component="form"
+			onSubmit={submitSearch}
+			sx={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 1,
+				bgcolor: 'background.paper',
+				border: '2px solid',
+				borderColor: 'primary.main',
+				borderRadius: 10,
+				paddingX: 2,
+				paddingY: 1.5,
+				boxShadow: 3,
+			}}
+		>
+			{searchInner}
+		</Box>
+	) : (
 		<Box
 			sx={{
 				background: gradient,
@@ -151,26 +167,7 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// tonal filled field — the only saturated icon on the page
-	const tonalSearchForm = (
-		<Box
-			component="form"
-			onSubmit={submitSearch}
-			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				gap: 1,
-				bgcolor: alpha(theme.palette.primary.main, 0.08),
-				borderRadius: 10,
-				paddingX: 2,
-				paddingY: 1.5,
-			}}
-		>
-			{searchInner}
-		</Box>
-	)
-
-	const loginLink = (textColor: string) => (
+	const loginLink = (
 		<Clickable>
 			<Link to="login" params={{ previousPage: '', message: '' }}>
 				<Box
@@ -178,7 +175,7 @@ function DemoMobilePage() {
 						display: 'flex',
 						alignItems: 'center',
 						gap: 0.5,
-						color: textColor,
+						color: 'primary.main',
 						paddingY: 0.5,
 					}}
 				>
@@ -200,14 +197,23 @@ function DemoMobilePage() {
 		/>
 	)
 
-	const heroTexts = (leadColor?: string) => (
-		<Box>
-			<Typography small color={leadColor} sx={leadColor ? {} : { opacity: 0.85 }}>
-				{tHome('hero.lead')}
-			</Typography>
-			<Typography variant="h3" strong={800}>
-				{tHome('hero.title')}
-			</Typography>
+	const headerRow = (
+		<Box
+			sx={{
+				display: 'flex',
+				justifyContent: 'space-between',
+				alignItems: 'end',
+			}}
+		>
+			<Box>
+				<Typography small color="grey.700">
+					{tHome('hero.lead')}
+				</Typography>
+				<Typography variant="h3" strong={800}>
+					{tHome('hero.title')}
+				</Typography>
+			</Box>
+			{loginLink}
 		</Box>
 	)
 
@@ -224,10 +230,10 @@ function DemoMobilePage() {
 	const sectionBadge = (icon: ReactNode) => (
 		<Box
 			sx={{
-				width: 28,
-				height: 28,
-				borderRadius: 1.5,
-				bgcolor: alpha(theme.palette.primary.main, 0.12),
+				width: 32,
+				height: 32,
+				borderRadius: 2,
+				bgcolor: alpha(theme.palette.primary.main, 0.1),
 				color: 'primary.main',
 				display: 'flex',
 				alignItems: 'center',
@@ -238,7 +244,8 @@ function DemoMobilePage() {
 		</Box>
 	)
 
-	// Shared section anatomy: header (title + optional action) + content panel
+	// Shared section anatomy: panel with header (badge in v4 + title +
+	// optional action) and content — identical geometry in every variant
 	const Section = ({
 		title,
 		icon,
@@ -249,72 +256,39 @@ function DemoMobilePage() {
 		icon: ReactNode
 		action?: ReactNode
 		children: ReactNode
-	}) => {
-		const header = (
+	}) => (
+		<Box sx={{ paddingX: 2.5 }}>
 			<Box
 				sx={{
+					bgcolor: panelBg,
+					borderRadius: 3,
+					boxShadow: panelShadow,
+					padding: 2,
 					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'space-between',
-					gap: 1,
+					flexDirection: 'column',
+					gap: 2,
 				}}
 			>
-				<Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-					{variant === 3 && sectionBadge(icon)}
-					<Typography variant="h6" strong>
-						{title}
-					</Typography>
-				</Box>
-				{action}
-			</Box>
-		)
-
-		if (variant === 3) {
-			return (
 				<Box
 					sx={{
 						display: 'flex',
-						flexDirection: 'column',
+						alignItems: 'center',
+						justifyContent: 'space-between',
 						gap: 1,
-						paddingX: 2.5,
 					}}
 				>
-					{header}
-					<Box
-						sx={{
-							bgcolor: panelBg,
-							borderRadius: 3,
-							padding: 1.5,
-							display: 'flex',
-							flexDirection: 'column',
-							gap: 1,
-						}}
-					>
-						{children}
+					<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+						{blueSystem && sectionBadge(icon)}
+						<Typography variant="h6" strong>
+							{title}
+						</Typography>
 					</Box>
+					{action}
 				</Box>
-			)
-		}
-
-		return (
-			<Box sx={{ paddingX: 2.5 }}>
-				<Box
-					sx={{
-						bgcolor: panelBg,
-						borderRadius: 3,
-						boxShadow: panelShadow,
-						padding: 2,
-						display: 'flex',
-						flexDirection: 'column',
-						gap: 2,
-					}}
-				>
-					{header}
-					{children}
-				</Box>
+				{children}
 			</Box>
-		)
-	}
+		</Box>
+	)
 
 	const carouselTile = (s: BasicVariantPack) => (
 		<Clickable key={s.packGuid}>
@@ -336,7 +310,7 @@ function DemoMobilePage() {
 							width: 36,
 							height: 36,
 							borderRadius: 1.5,
-							bgcolor: alpha(theme.palette.primary.main, 0.12),
+							bgcolor: alpha(theme.palette.primary.main, 0.1),
 							color: 'primary.main',
 							display: 'flex',
 							alignItems: 'center',
@@ -395,68 +369,14 @@ function DemoMobilePage() {
 					maxWidth: PAGE_MAX_WIDTH,
 					minWidth: 0,
 					minHeight: '100dvh',
-					bgcolor: variant === 1 ? 'grey.100' : 'background.paper',
+					bgcolor: canvasBg,
 					display: 'flex',
 					flexDirection: 'column',
 					boxShadow: 3,
 				}}
 			>
-				{/* ===================== HEADER + SEARCH ===================== */}
-				{variant === 2 ? (
-					<Box
-						sx={{
-							background: gradient,
-							color: 'common.white',
-							paddingX: 2.5,
-							paddingTop: 'calc(env(safe-area-inset-top) + 20px)',
-							paddingBottom: 3.5,
-							borderRadius: '0 0 28px 28px',
-							position: 'relative',
-							overflow: 'hidden',
-							display: 'flex',
-							flexDirection: 'column',
-							gap: 2.5,
-						}}
-					>
-						<Box
-							sx={{
-								position: 'absolute',
-								right: 16,
-								top: 'calc(env(safe-area-inset-top) + 52px)',
-								pointerEvents: 'none',
-								opacity: 0.95,
-							}}
-						>
-							{sheep(72)}
-						</Box>
-						<Box
-							sx={{
-								display: 'flex',
-								justifyContent: 'space-between',
-								alignItems: 'start',
-							}}
-						>
-							{heroTexts()}
-							{loginLink('common.white')}
-						</Box>
-						<Box
-							component="form"
-							onSubmit={submitSearch}
-							sx={{
-								display: 'flex',
-								alignItems: 'center',
-								gap: 1,
-								bgcolor: 'background.paper',
-								borderRadius: 10,
-								paddingX: 2,
-								paddingY: 1.5,
-								boxShadow: 2,
-							}}
-						>
-							{searchInner}
-						</Box>
-					</Box>
-				) : variant === 4 ? (
+				{/* ===================== HEADER (+ top/centered search) ===================== */}
+				{searchCentered ? (
 					// hero fills the upper half so the search lands mid-screen,
 					// inside comfortable thumb reach
 					<Box
@@ -470,16 +390,7 @@ function DemoMobilePage() {
 							gap: 2.5,
 						}}
 					>
-						<Box
-							sx={{
-								display: 'flex',
-								justifyContent: 'space-between',
-								alignItems: 'end',
-							}}
-						>
-							{heroTexts('grey.700')}
-							{loginLink('primary.main')}
-						</Box>
+						{headerRow}
 						<Box
 							sx={{
 								flex: 1,
@@ -489,9 +400,9 @@ function DemoMobilePage() {
 								pointerEvents: 'none',
 							}}
 						>
-							{sheep(128)}
+							{sheep(120)}
 						</Box>
-						{gradientSearchForm}
+						{searchForm}
 					</Box>
 				) : (
 					<Box
@@ -503,19 +414,8 @@ function DemoMobilePage() {
 							gap: 2.5,
 						}}
 					>
-						<Box
-							sx={{
-								display: 'flex',
-								justifyContent: 'space-between',
-								alignItems: 'end',
-							}}
-						>
-							{heroTexts('grey.700')}
-							{loginLink('primary.main')}
-						</Box>
-
-						{variant === 1 && gradientSearchForm}
-						{variant === 3 && tonalSearchForm}
+						{headerRow}
+						{!searchDocked && searchForm}
 					</Box>
 				)}
 
@@ -527,80 +427,86 @@ function DemoMobilePage() {
 						flexDirection: 'column',
 						gap: 2.5,
 						paddingTop: 2.5,
-						// v5 also needs room for the docked search bar
-						paddingBottom:
-							variant === 5
-								? 'calc(env(safe-area-inset-bottom) + 156px)'
-								: BOTTOM_NAV_CLEARANCE,
+						paddingBottom: searchDocked
+							? DOCKED_SEARCH_CLEARANCE
+							: TAB_BAR_CLEARANCE,
 					}}
 				>
 					<Section
 						title={tHome('recommended.idea')}
 						icon={<AutoAwesomeRounded sx={{ fontSize: 18 }} />}
 					>
-						<Box sx={{ display: 'flex', flexDirection: 'column', gap: rowsHaveDividers ? 0 : 1 }}>
+						<Box
+							sx={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: rowsHaveDividers ? 0 : 1,
+							}}
+						>
 							{recommended.isLoading
 								? listSkeletons
-								: recommended.data.slice(0, showLastAdded ? 4 : 6).map((s, i, arr) => (
-										<Fragment key={s.packGuid}>
-											<SongVariantCard
-												data={s}
-												dense
-												sx={{
-													bgcolor: rowBg,
-													borderRadius: rowsHaveDividers ? 0 : 2,
-												}}
-											/>
-											{rowsHaveDividers && i < arr.length - 1 && (
-												<Divider sx={{ marginX: 1 }} />
-											)}
-										</Fragment>
-								  ))}
+								: recommended.data
+										.slice(0, showLastAdded ? 4 : 6)
+										.map((s, i, arr) => (
+											<Fragment key={s.packGuid}>
+												<SongVariantCard
+													data={s}
+													dense
+													sx={{
+														bgcolor: rowBg,
+														borderRadius: rowsHaveDividers ? 0 : 2,
+													}}
+												/>
+												{rowsHaveDividers && i < arr.length - 1 && (
+													<Divider sx={{ marginX: 1 }} />
+												)}
+											</Fragment>
+										))}
 						</Box>
 					</Section>
 
 					{showLastAdded && (
-					<Section
-						title={tHome('lastAdded.title')}
-						icon={<ScheduleRounded sx={{ fontSize: 18 }} />}
-						action={browseAction}
-					>
-						<Box
-							sx={{
-								display: 'flex',
-								gap: 1.5,
-								overflowX: 'auto',
-								// bleed the scroll area to the panel edges, then restore
-								// the inset inside it so tiles align with the header text
-								marginX: variant === 3 ? -1.5 : -2,
-								paddingLeft: variant === 3 ? 1.5 : 2,
-								paddingY: 0.5,
-								scrollSnapType: 'x mandatory',
-								scrollPaddingLeft: theme.spacing(2),
-								'&::-webkit-scrollbar': { display: 'none' },
-								// keeps the right inset visible at the end of the scroll
-								// (trailing padding collapses in overflow containers)
-								'&::after': {
-									content: '""',
-									flex: '0 0 1px',
-								},
-							}}
+						<Section
+							title={tHome('lastAdded.title')}
+							icon={<ScheduleRounded sx={{ fontSize: 18 }} />}
+							action={browseAction}
 						>
-							{lastAdded.isLoading
-								? carouselSkeletons
-								: lastAdded.data.slice(0, 8).map((s) => carouselTile(s))}
-						</Box>
-					</Section>
+							<Box
+								sx={{
+									display: 'flex',
+									gap: 1.5,
+									overflowX: 'auto',
+									// bleed the scroll area to the panel edges, then restore
+									// the inset inside it so tiles align with the header text
+									marginX: -2,
+									paddingLeft: 2,
+									paddingY: 0.5,
+									scrollSnapType: 'x mandatory',
+									scrollPaddingLeft: theme.spacing(2),
+									'&::-webkit-scrollbar': { display: 'none' },
+									// keeps the right inset visible at the end of the scroll
+									// (trailing padding collapses in overflow containers)
+									'&::after': {
+										content: '""',
+										flex: '0 0 1px',
+									},
+								}}
+							>
+								{lastAdded.isLoading
+									? carouselSkeletons
+									: lastAdded.data.slice(0, 8).map((s) => carouselTile(s))}
+							</Box>
+						</Section>
 					)}
 
 					{/* ===================== CTA ===================== */}
-					{variant === 3 ? (
+					{blueSystem ? (
 						<Box sx={{ paddingX: 2.5 }}>
 							<Box
 								sx={{
 									bgcolor: panelBg,
 									borderRadius: 3,
-									padding: 2.5,
+									padding: 2,
 									display: 'flex',
 									flexDirection: 'column',
 									gap: 1.5,
@@ -611,7 +517,7 @@ function DemoMobilePage() {
 									sx={{
 										position: 'absolute',
 										top: -34,
-										right: 12,
+										right: 16,
 										pointerEvents: 'none',
 									}}
 								>
@@ -683,7 +589,7 @@ function DemoMobilePage() {
 				</Box>
 
 				{/* ===== Docked search — floats above the tab bar (thumb zone) ===== */}
-				{variant === 5 && (
+				{searchDocked && (
 					<Box
 						sx={{
 							position: 'fixed',
@@ -696,7 +602,7 @@ function DemoMobilePage() {
 							zIndex: 10,
 						}}
 					>
-						{gradientSearchForm}
+						{searchForm}
 					</Box>
 				)}
 
@@ -722,21 +628,21 @@ function DemoMobilePage() {
 							icon={<HomeRounded />}
 							label={tNav('home')}
 							active
-							pill={variant === 3}
+							pill={blueSystem}
 						/>
 					</Link>
 					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
 						<TabItem
 							icon={<QueueMusicRounded />}
 							label={tNav('songs')}
-							pill={variant === 3}
+							pill={blueSystem}
 						/>
 					</Link>
 					<Link to="account" params={{}} style={{ flex: 1 }}>
 						<TabItem
 							icon={<PersonOutlineRounded />}
 							label={tNav('account')}
-							pill={variant === 3}
+							pill={blueSystem}
 						/>
 					</Link>
 				</Box>
@@ -775,7 +681,7 @@ function TabItem({ icon, label, active, pill }: TabItemProps) {
 						paddingX: 2,
 						borderRadius: 10,
 						bgcolor: active
-							? alpha(theme.palette.primary.main, 0.14)
+							? alpha(theme.palette.primary.main, 0.12)
 							: 'transparent',
 					}),
 				}}

--- a/src/app/(layout)/demo-mobil/page.tsx
+++ b/src/app/(layout)/demo-mobil/page.tsx
@@ -250,7 +250,7 @@ function DemoMobilePage() {
 						padding: 2,
 						display: 'flex',
 						flexDirection: 'column',
-						gap: 1.5,
+						gap: 2,
 					}}
 				>
 					{header}
@@ -265,26 +265,27 @@ function DemoMobilePage() {
 			<Link to="variant" params={parseVariantAlias(s.packAlias)}>
 				<Box
 					sx={{
-						width: 156,
+						width: 164,
 						bgcolor: tileBg,
 						borderRadius: 2,
-						padding: 1.5,
+						padding: 2,
 						scrollSnapAlign: 'start',
 						display: 'flex',
 						flexDirection: 'column',
-						gap: 1,
+						gap: 0.75,
 					}}
 				>
 					<Box
 						sx={{
-							width: 32,
-							height: 32,
+							width: 36,
+							height: 36,
 							borderRadius: 1.5,
 							bgcolor: alpha(theme.palette.primary.main, 0.12),
 							color: 'primary.main',
 							display: 'flex',
 							alignItems: 'center',
 							justifyContent: 'center',
+							marginBottom: 0.75,
 						}}
 					>
 						<MusicNoteRounded fontSize="small" />
@@ -314,7 +315,7 @@ function DemoMobilePage() {
 		<Skeleton
 			key={i}
 			variant="rounded"
-			sx={{ minWidth: 156, height: 112, borderRadius: 2, bgcolor: 'grey.200' }}
+			sx={{ minWidth: 164, height: 128, borderRadius: 2, bgcolor: 'grey.200' }}
 		/>
 	))
 
@@ -511,13 +512,22 @@ function DemoMobilePage() {
 						<Box
 							sx={{
 								display: 'flex',
-								gap: 1,
+								gap: 1.5,
 								overflowX: 'auto',
-								// bleed the scroll area to the panel edges
+								// bleed the scroll area to the panel edges, then restore
+								// the inset inside it so tiles align with the header text
 								marginX: variant === 3 ? -1.5 : -2,
-								paddingX: variant === 3 ? 1.5 : 2,
+								paddingLeft: variant === 3 ? 1.5 : 2,
+								paddingY: 0.5,
 								scrollSnapType: 'x mandatory',
+								scrollPaddingLeft: theme.spacing(2),
 								'&::-webkit-scrollbar': { display: 'none' },
+								// keeps the right inset visible at the end of the scroll
+								// (trailing padding collapses in overflow containers)
+								'&::after': {
+									content: '""',
+									flex: '0 0 1px',
+								},
 							}}
 						>
 							{lastAdded.isLoading

--- a/src/app/(layout)/pisen/[hex]/[alias]/page.tsx
+++ b/src/app/(layout)/pisen/[hex]/[alias]/page.tsx
@@ -21,7 +21,7 @@ type SongRoutePageProps = {
 	params: SmartParams<'variant'>
 }
 
-export default SmartPage(SongRoutePage)
+export default SmartPage(SongRoutePage, ['mobileTabBar'])
 
 async function SongRoutePage({ params }: SongRoutePageProps) {
 	const alias = getVariantAliasFromParams(params.hex, params.alias)

--- a/src/app/(layout)/seznam/page.tsx
+++ b/src/app/(layout)/seznam/page.tsx
@@ -12,7 +12,7 @@ import { Gap } from '../../../common/ui/Gap/Gap'
 import { useSmartUrlState } from '../../../hooks/urlstate/useUrlState'
 import { useTranslations } from 'next-intl'
 
-export default SmartPage(List)
+export default SmartPage(List, { mobileTabBar: true })
 function List() {
 	const t = useTranslations('songsList')
 	const [page, setPage] = useSmartUrlState('songsList', 's', {

--- a/src/app/(layout)/ucet/oblibene/page.tsx
+++ b/src/app/(layout)/ucet/oblibene/page.tsx
@@ -16,7 +16,7 @@ import {
 import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 
-export default SmartPage(page, ['middleWidth', 'topPadding'])
+export default SmartPage(page, ['middleWidth', 'topPadding', 'mobileTabBar'])
 
 export type FavouriteItem = {
 	data: PlaylistItemDto

--- a/src/app/(layout)/ucet/page.tsx
+++ b/src/app/(layout)/ucet/page.tsx
@@ -9,7 +9,7 @@ import { useSmartNavigate } from '../../../routes/useSmartNavigate'
 import BasicInfo from './components/BasicInfo'
 import TabsPanel from './components/TabsPanel'
 
-export default SmartPage(Account)
+export default SmartPage(Account, { mobileTabBar: true })
 function Account() {
 	const { isLoggedIn } = useAuth()
 

--- a/src/app/(layout)/ucet/pisne/page.tsx
+++ b/src/app/(layout)/ucet/pisne/page.tsx
@@ -17,7 +17,7 @@ import { useMemo, useState } from 'react'
 import { mapBasicVariantPackApiToDto } from '../../../../api/dtos'
 import { useApi } from '../../../../api/tech-and-hooks/useApi'
 
-export default SmartPage(MySongsList, ['middleWidth'])
+export default SmartPage(MySongsList, ['middleWidth', 'mobileTabBar'])
 
 function MySongsList() {
 	const { songGettingApi } = useApi()

--- a/src/app/(layout)/ucet/playlisty/page.tsx
+++ b/src/app/(layout)/ucet/playlisty/page.tsx
@@ -14,7 +14,7 @@ import { useUrlState } from '@/hooks/urlstate/useUrlState'
 import { PlaylistGuid } from '@/interfaces/playlist/playlist.types'
 import { useMemo, useState } from 'react'
 
-export default SmartPage(Playlists, ['middleWidth'])
+export default SmartPage(Playlists, ['middleWidth', 'mobileTabBar'])
 
 function Playlists() {
 	const { playlists: allPlaylists, loading } = useUsersPlaylists()

--- a/src/app/components/HomeDesktop.tsx
+++ b/src/app/components/HomeDesktop.tsx
@@ -20,6 +20,7 @@ import ContainerGrid, {
 	containerMaxWidth,
 } from '../../common/components/ContainerGrid'
 import FloatingAddButton from './components/FloatingAddButton'
+import HomeMobile from './HomeMobile'
 import SearchedSongsList from './components/SearchedSongsList'
 
 export const RESET_HOME_SCREEN_EVENT_NAME = 'reset_home_screen_jh1a94'
@@ -90,6 +91,12 @@ export default function HomeDesktop() {
 	const footer = useFooter()
 
 	useEffect(() => {
+		// mobile home runs its own shell (bottom tab bar + docked search), so the
+		// top toolbar is hidden here and restored when leaving the mobile home
+		if (phoneVersion) {
+			toolbar.setHidden(true)
+			return () => toolbar.setHidden(false)
+		}
 		toolbar.setTransparent(isTop)
 		toolbar.setHideMiddleNavigation(!isTop)
 		toolbar.setShowTitle(!isTop)
@@ -127,120 +134,52 @@ export default function HomeDesktop() {
 	const heroLead = tHome('hero.lead')
 	const heroTitle = tHome('hero.title')
 	const heroSubtitle = tHome('hero.subtitle')
-	const heroSubtitleLower = tHome('hero.subtitleLower')
 	return (
 		<>
-			<Box
-				sx={{
-					position: 'fixed',
-					top: isTop ? (phoneVersion ? '20vh' : '38vh') : '-100%',
-					right: isTop ? 0 : '-100%',
-					transform: 'translateX(50%) translateY(-50%) rotate(175deg)',
-					zIndex: -1,
-					pointerEvents: 'none',
-					transition: 'top 0.2s ease, right 0.2s ease, opacity 0.2s ease',
-					width: shapeSizeString,
-					height: shapeSizeString,
-				}}
-			>
-				<Image
-					src={getAssetUrl('/gradient-shapes/shape1.svg')}
-					alt={tHome('backgroundShape')}
-					fill
-					priority
-					sizes="(max-width: 700px) 88vw, calc(max(50vw, 50vh) * 1.35)"
-					style={{
-						filter: 'brightness(1)',
-					}}
-				/>
-				<Image
-					src={getAssetUrl('/gradient-shapes/shape2.svg')}
-					alt={tHome('backgroundShape')}
-					fill
-					priority
-					sizes="(max-width: 700px) 88vw, calc(max(50vw, 50vh) * 1.35)"
-					style={{
-						filter: 'brightness(1.1)',
-					}}
-				/>
-			</Box>
-
-			{phoneVersion ? (
+			{!phoneVersion && (
 				<Box
 					sx={{
-						flex: 1,
-						display: 'flex',
-						flexDirection: 'column',
-						position: 'relative',
-						paddingX: 2,
-						paddingTop: 2,
+						position: 'fixed',
+						top: isTop ? '38vh' : '-100%',
+						right: isTop ? 0 : '-100%',
+						transform: 'translateX(50%) translateY(-50%) rotate(175deg)',
+						zIndex: -1,
+						pointerEvents: 'none',
+						transition: 'top 0.2s ease, right 0.2s ease, opacity 0.2s ease',
+						width: shapeSizeString,
+						height: shapeSizeString,
 					}}
 				>
-					<Box
-						sx={{
-							display: 'flex',
-							flexDirection: 'column',
-							paddingBottom: 2,
+					<Image
+						src={getAssetUrl('/gradient-shapes/shape1.svg')}
+						alt={tHome('backgroundShape')}
+						fill
+						priority
+						sizes="(max-width: 700px) 88vw, calc(max(50vw, 50vh) * 1.35)"
+						style={{
+							filter: 'brightness(1)',
 						}}
-					>
-						<Typography variant="h4" strong={200}>
-							{heroLead}
-						</Typography>
-						<Typography variant="h3" strong={900} noWrap>
-							{heroTitle}
-						</Typography>
-
-						{useWorshipVersion && (
-							<Typography variant="h4" strong={200} noWrap>
-								{heroSubtitleLower}
-							</Typography>
-						)}
-					</Box>
-
-					<Box
-						sx={{
-							position: 'sticky',
-							// 56px = Toolbar height (TopBar in Toolbar.tsx)
-							top: theme.spacing(7),
-							zIndex: 2,
+					/>
+					<Image
+						src={getAssetUrl('/gradient-shapes/shape2.svg')}
+						alt={tHome('backgroundShape')}
+						fill
+						priority
+						sizes="(max-width: 700px) 88vw, calc(max(50vw, 50vh) * 1.35)"
+						style={{
+							filter: 'brightness(1.1)',
 						}}
-					>
-						<MainSearchInput
-							gradientBorder={isTop}
-							autoFocus={false}
-							value={searchInputValue}
-							onChange={onSearchValueChange}
-							smartSearch={smartSearch ?? false}
-							onSmartSearchChange={setSmartSearch}
-						/>
-					</Box>
-
-					<Box
-						sx={{
-							display: 'flex',
-							flexDirection: 'column',
-							alignItems: 'center',
-							paddingTop: 3,
-						}}
-					>
-						{searchString && (
-							<SearchedSongsList
-								searchString={searchString}
-								useSmartSearch={smartSearch ?? false}
-								dense
-							/>
-						)}
-						<RecommendedSongsList dense />
-						<Box
-							sx={{
-								paddingTop: 14,
-								paddingBottom: 4,
-							}}
-						>
-							<RightSheepPanel mobileVersion />
-						</Box>
-					</Box>
+					/>
 				</Box>
+			)}
+
+			{phoneVersion ? (
+				<HomeMobile
+					searchInputValue={searchInputValue}
+					onSearchValueChange={onSearchValueChange}
+					searchString={searchString}
+					smartSearch={smartSearch ?? false}
+				/>
 			) : (
 				<Box
 					sx={{

--- a/src/app/components/HomeDesktop.tsx
+++ b/src/app/components/HomeDesktop.tsx
@@ -29,7 +29,6 @@ const ANIMATION_DURATION = 0.2
 export default function HomeDesktop() {
 	const theme = useTheme()
 	const phoneVersion = useMediaQuery(theme.breakpoints.down(700))
-	const isMobile = phoneVersion
 	const tHome = useTranslations('home')
 
 	const scrollPointRef = useRef(null)
@@ -122,7 +121,9 @@ export default function HomeDesktop() {
 	const paddingX = 32
 	const gapString = `calc(max(${paddingX}px, (100vw - ${containerMaxWidth}px) / 2) )`
 
-	const shapeSizeString = `calc(max(50vw, 50vh) * 1.35)`
+	const shapeSizeString = phoneVersion
+		? `calc(max(70vw, 40vh))`
+		: `calc(max(50vw, 50vh) * 1.35)`
 	const heroLead = tHome('hero.lead')
 	const heroTitle = tHome('hero.title')
 	const heroSubtitle = tHome('hero.subtitle')
@@ -132,11 +133,11 @@ export default function HomeDesktop() {
 			<Box
 				sx={{
 					position: 'fixed',
-					top: isTop ? '38vh' : '-100%',
+					top: isTop ? (phoneVersion ? '20vh' : '38vh') : '-100%',
 					right: isTop ? 0 : '-100%',
 					transform: 'translateX(50%) translateY(-50%) rotate(175deg)',
 					zIndex: -1,
-					opacity: isMobile ? 0 : 1,
+					pointerEvents: 'none',
 					transition: 'top 0.2s ease, right 0.2s ease, opacity 0.2s ease',
 					width: shapeSizeString,
 					height: shapeSizeString,
@@ -147,7 +148,7 @@ export default function HomeDesktop() {
 					alt={tHome('backgroundShape')}
 					fill
 					priority
-					sizes="(max-width: 700px) 0px, calc(max(50vw, 50vh) * 1.35)"
+					sizes="(max-width: 700px) 88vw, calc(max(50vw, 50vh) * 1.35)"
 					style={{
 						filter: 'brightness(1)',
 					}}
@@ -157,93 +158,148 @@ export default function HomeDesktop() {
 					alt={tHome('backgroundShape')}
 					fill
 					priority
-					sizes="(max-width: 700px) 0px, calc(max(50vw, 50vh) * 1.35)"
+					sizes="(max-width: 700px) 88vw, calc(max(50vw, 50vh) * 1.35)"
 					style={{
 						filter: 'brightness(1.1)',
 					}}
 				/>
 			</Box>
 
-			<Box
-				sx={{
-					flex: 1,
-					justifyContent: 'center',
-					alignItems: 'start',
-					display: 'flex',
-					flexDirection: 'column',
-					position: 'relative',
-				}}
-			>
-				<motion.div
-					style={{
-						position: 'fixed',
+			{phoneVersion ? (
+				<Box
+					sx={{
+						flex: 1,
 						display: 'flex',
 						flexDirection: 'column',
-						zIndex: phoneVersion ? 1 : 10,
-						alignItems: 'center',
-						pointerEvents: 'none',
-					}}
-					initial={{
-						top: !phoneVersion
-							? isTop
-								? `32%`
-								: 'calc(-7rem + 22px)'
-							: isTop
-							? '64px'
-							: 'calc( 64px - 64px)',
-
-						left: !phoneVersion ? paddingX : theme.spacing(1),
-						right: !phoneVersion ? paddingX : theme.spacing(1),
-					}}
-					animate={{
-						// position: phoneVersion ? 'sticky' : 'fixed',
-						top: !phoneVersion
-							? isTop
-								? `32%`
-								: 'calc(-7rem + 22px - 24px)'
-							: isTop
-							? '64px'
-							: 'calc( 64px - 64px)',
-
-						left: !phoneVersion
-							? isTop
-								? paddingX
-								: `calc( ${paddingX}px + ${gapString} )`
-							: theme.spacing(1),
-						right: !phoneVersion ? paddingX : theme.spacing(1),
-					}}
-					transition={{
-						type: 'keyframes',
-						duration: ANIMATION_DURATION,
+						position: 'relative',
+						paddingX: 2,
+						paddingTop: 2,
 					}}
 				>
-					<ContainerGrid>
+					<Box
+						sx={{
+							display: 'flex',
+							flexDirection: 'column',
+							paddingBottom: 2,
+						}}
+					>
+						<Typography variant="h4" strong={200}>
+							{heroLead}
+						</Typography>
+						<Typography variant="h3" strong={900} noWrap>
+							{heroTitle}
+						</Typography>
+
+						{useWorshipVersion && (
+							<Typography variant="h4" strong={200} noWrap>
+								{heroSubtitleLower}
+							</Typography>
+						)}
+					</Box>
+
+					<Box
+						sx={{
+							position: 'sticky',
+							top: theme.spacing(7),
+							zIndex: 2,
+						}}
+					>
+						<MainSearchInput
+							gradientBorder={isTop}
+							autoFocus={false}
+							value={searchInputValue}
+							onChange={onSearchValueChange}
+							smartSearch={smartSearch ?? false}
+							onSmartSearchChange={setSmartSearch}
+						/>
+					</Box>
+
+					<Box
+						sx={{
+							display: 'flex',
+							flexDirection: 'column',
+							alignItems: 'center',
+							paddingTop: 3,
+						}}
+					>
+						{searchString && (
+							<SearchedSongsList
+								searchString={searchString}
+								useSmartSearch={smartSearch ?? false}
+							/>
+						)}
+						<RecommendedSongsList />
 						<Box
 							sx={{
-								display: 'flex',
-								justifyContent: ' space-between',
-								width: '100%',
-								gap: gapString,
+								paddingTop: 14,
+								paddingBottom: 4,
 							}}
 						>
+							<RightSheepPanel mobileVersion />
+						</Box>
+					</Box>
+				</Box>
+			) : (
+				<Box
+					sx={{
+						flex: 1,
+						justifyContent: 'center',
+						alignItems: 'start',
+						display: 'flex',
+						flexDirection: 'column',
+						position: 'relative',
+					}}
+				>
+					<motion.div
+						style={{
+							position: 'fixed',
+							display: 'flex',
+							flexDirection: 'column',
+							zIndex: 10,
+							alignItems: 'center',
+							pointerEvents: 'none',
+						}}
+						initial={{
+							top: isTop ? `32%` : 'calc(-7rem + 22px)',
+							left: paddingX,
+							right: paddingX,
+						}}
+						animate={{
+							top: isTop ? `32%` : 'calc(-7rem + 22px - 24px)',
+							left: isTop ? paddingX : `calc( ${paddingX}px + ${gapString} )`,
+							right: paddingX,
+						}}
+						transition={{
+							type: 'keyframes',
+							duration: ANIMATION_DURATION,
+						}}
+					>
+						<ContainerGrid>
 							<Box
-								flex={1}
 								sx={{
 									display: 'flex',
-									justifyContent: 'center',
+									justifyContent: ' space-between',
+									width: '100%',
+									gap: gapString,
 								}}
 							>
 								<Box
-									maxWidth={isMobile ? '100vw' : `min(550px, 50vw)`}
 									flex={1}
 									sx={{
 										display: 'flex',
-										flexDirection: 'column',
-										gap: isMobile ? 1 : 3,
+										justifyContent: 'center',
 									}}
 								>
-									<AnimatePresence>
-										{!phoneVersion ? (
+									<Box
+										maxWidth={`min(550px, 50vw)`}
+										flex={1}
+										sx={{
+											display: 'flex',
+											flexDirection: 'column',
+											gap: 3,
+										}}
+									>
+										<AnimatePresence>
 											<motion.div
 												initial={{
 													height: '7rem',
@@ -304,42 +360,18 @@ export default function HomeDesktop() {
 													</>
 												)}
 											</motion.div>
-										) : (
-											<Box
-												sx={{
-													display: 'flex',
-													flexDirection: 'column',
-												}}
-											>
-												<Typography variant="h4" strong={200}>
-													{heroLead}
-												</Typography>
-												<Typography variant="h3" strong={900} noWrap>
-													{heroTitle}
-												</Typography>
+										</AnimatePresence>
 
-												{useWorshipVersion && (
-													<>
-														<Typography variant="h4" strong={200} noWrap>
-															{heroSubtitleLower}
-														</Typography>
-													</>
-												)}
-											</Box>
-										)}
-									</AnimatePresence>
-
-									<MainSearchInput
-										gradientBorder={isTop && !phoneVersion}
-										value={searchInputValue}
-										onChange={onSearchValueChange}
-										smartSearch={smartSearch ?? false}
-										onSmartSearchChange={setSmartSearch}
-									/>
+										<MainSearchInput
+											gradientBorder={isTop}
+											value={searchInputValue}
+											onChange={onSearchValueChange}
+											smartSearch={smartSearch ?? false}
+											onSmartSearchChange={setSmartSearch}
+										/>
+									</Box>
 								</Box>
-							</Box>
 
-							{!isMobile && (
 								<Box
 									sx={{
 										maxWidth: isTop ? 500 : 0,
@@ -354,52 +386,41 @@ export default function HomeDesktop() {
 										pointerEvents: 'auto',
 									}}
 								>
-									<RightSheepPanel mobileVersion={isMobile} />
+									<RightSheepPanel mobileVersion={false} />
 								</Box>
-							)}
-						</Box>
-					</ContainerGrid>
-				</motion.div>
-				<Box sx={{ height: 65 }}></Box>
-				<div ref={scrollPointRef}></div>
-				<Box sx={{ height: !phoneVersion ? '100vh' : 0 }}></Box>
-				<div
-					style={{
-						left: 0,
-						right: 0,
-						position: 'absolute',
-						display: 'flex',
-						flexDirection: 'column',
-						alignItems: 'center',
-						padding: 0,
-						top: !phoneVersion ? 'calc(100% - 275px)' : '155px',
-						// TODO: fix height jumping on one column preview
-						transform:
-							isTop || phoneVersion
+							</Box>
+						</ContainerGrid>
+					</motion.div>
+					<Box sx={{ height: 65 }}></Box>
+					<div ref={scrollPointRef}></div>
+					<Box sx={{ height: '100vh' }}></Box>
+					<div
+						style={{
+							left: 0,
+							right: 0,
+							position: 'absolute',
+							display: 'flex',
+							flexDirection: 'column',
+							alignItems: 'center',
+							padding: 0,
+							top: 'calc(100% - 275px)',
+							// TODO: fix height jumping on one column preview
+							transform: isTop
 								? 'translateY(0)'
 								: `translateY(calc(-${innerHeight}*0.8px + 170px))`,
-						transition: `all ${ANIMATION_DURATION}s ease`,
-					}}
-				>
-					{searchString && (
-						<SearchedSongsList
-							searchString={searchString}
-							useSmartSearch={smartSearch ?? false}
-						/>
-					)}
-					<RecommendedSongsList />
-					{isMobile && (
-						<Box
-							sx={{
-								paddingTop: 16,
-								paddingBottom: 4,
-							}}
-						>
-							<RightSheepPanel mobileVersion={isMobile} />
-						</Box>
-					)}
-				</div>
-			</Box>
+							transition: `all ${ANIMATION_DURATION}s ease`,
+						}}
+					>
+						{searchString && (
+							<SearchedSongsList
+								searchString={searchString}
+								useSmartSearch={smartSearch ?? false}
+							/>
+						)}
+						<RecommendedSongsList />
+					</div>
+				</Box>
+			)}
 
 			{!phoneVersion ? (
 				<FloatingAddButton extended={!isTop} />

--- a/src/app/components/HomeDesktop.tsx
+++ b/src/app/components/HomeDesktop.tsx
@@ -200,6 +200,7 @@ export default function HomeDesktop() {
 					<Box
 						sx={{
 							position: 'sticky',
+							// 56px = Toolbar height (TopBar in Toolbar.tsx)
 							top: theme.spacing(7),
 							zIndex: 2,
 						}}
@@ -226,9 +227,10 @@ export default function HomeDesktop() {
 							<SearchedSongsList
 								searchString={searchString}
 								useSmartSearch={smartSearch ?? false}
+								dense
 							/>
 						)}
-						<RecommendedSongsList />
+						<RecommendedSongsList dense />
 						<Box
 							sx={{
 								paddingTop: 14,

--- a/src/app/components/HomeMobile.tsx
+++ b/src/app/components/HomeMobile.tsx
@@ -9,6 +9,10 @@ import { Skeleton } from '@/common/ui/mui/Skeleton'
 import { SongVariantCard } from '@/common/ui/SongCard'
 import { TextField } from '@/common/ui/TextField'
 import useAuth from '@/hooks/auth/useAuth'
+import { useUrlState } from '@/hooks/urlstate/useUrlState'
+import useSongSearch from '@/hooks/song/useSongSearch'
+import { SearchSongDto } from '@/api/dtos/song/song.search.dto'
+import { SearchKey } from '@/types/song/search.types'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import {
@@ -23,7 +27,8 @@ import {
 	SearchRounded,
 } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
-import { ReactNode } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
+import MainSearchInput from './components/MainSearchInput'
 import SearchedSongsList from './components/SearchedSongsList'
 
 const PAGE_MAX_WIDTH = 480
@@ -69,6 +74,14 @@ export default function HomeMobile({
 
 	const loggedIn = isLoggedIn()
 	const searching = searchInputValue.trim().length > 0
+
+	// temporary variant switches (remove once a look is chosen):
+	//   ?sf= search field   1 = white gradient-border (default) · 2 = house MainSearchInput
+	//   ?sr= search results 1 = shared list (default) · 2 = white cards · 3 = quiet list
+	const [sfParam] = useUrlState('sf')
+	const [srParam] = useUrlState('sr')
+	const sf = Number(sfParam) === 2 ? 2 : 1
+	const sr = Number(srParam) === 2 ? 2 : Number(srParam) === 3 ? 3 : 1
 
 	// ---- header ------------------------------------------------------
 
@@ -190,14 +203,18 @@ export default function HomeMobile({
 	const results = (
 		<Box sx={{ paddingX: 2.5 }}>
 			{searchString ? (
-				<SearchedSongsList searchString={searchString} useSmartSearch={smartSearch} dense />
+				sr === 1 ? (
+					<SearchedSongsList searchString={searchString} useSmartSearch={smartSearch} dense />
+				) : (
+					<MobileSearchResults searchString={searchString} smartSearch={smartSearch} variant={sr === 2 ? 'cards' : 'list'} />
+				)
 			) : null}
 		</Box>
 	)
 
 	// ---- docked search: buttonless field with a primary gradient border
 
-	const search = (
+	const handmadeSearch = (
 		<Box
 			component="form"
 			onSubmit={(e) => {
@@ -230,6 +247,15 @@ export default function HomeMobile({
 			</Box>
 		</Box>
 	)
+
+	const search =
+		sf === 2 ? (
+			<Box sx={{ boxShadow: 2, borderRadius: '0.6rem' }}>
+				<MainSearchInput gradientBorder value={searchInputValue} onChange={onSearchValueChange} autoFocus={false} smartSearch={smartSearch} />
+			</Box>
+		) : (
+			handmadeSearch
+		)
 
 	const heroBg = `linear-gradient(to bottom, ${theme.palette.common.white} 0%, ${theme.palette.common.white} ${WASH_SOLID_STOP}%, ${theme.palette.grey[100]} ${WASH_GREY_STOP}%)`
 
@@ -350,6 +376,86 @@ function TabItem({ icon, activeIcon, label, active }: TabItemProps) {
 			<Typography small strong={active ? 700 : 400}>
 				{label}
 			</Typography>
+		</Box>
+	)
+}
+
+/**
+ * Variant renderer for the search results so we can compare looks:
+ *  - 'cards' — white floating cards, matching the recommended picks
+ *  - 'list'  — a quiet title-only list with dividers
+ * (variant 'shared' keeps the existing SearchedSongsList; handled by the caller)
+ */
+function MobileSearchResults({
+	searchString,
+	smartSearch,
+	variant,
+}: {
+	searchString: string
+	smartSearch: boolean
+	variant: 'cards' | 'list'
+}) {
+	const tHome = useTranslations('home')
+	const searchSongs = useSongSearch()
+	const [songs, setSongs] = useState<SearchSongDto[]>([])
+	const [loading, setLoading] = useState(true)
+
+	useEffect(() => {
+		let active = true
+		setLoading(true)
+		searchSongs(searchString as SearchKey, { page: 0, useSmartSearch: smartSearch })
+			.then((data) => {
+				if (!active) return
+				setSongs(data)
+				setLoading(false)
+			})
+			.catch(() => {
+				if (!active) return
+				setSongs([])
+				setLoading(false)
+			})
+		return () => {
+			active = false
+		}
+	}, [searchString, smartSearch, searchSongs])
+
+	const packs = songs.flatMap((s) => s.found)
+
+	return (
+		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+			<Typography small strong uppercase color="grey.700" sx={{ paddingX: 0.5 }}>
+				{tHome('search.resultsTitle').replace(/:$/, '')}
+			</Typography>
+			{loading ? (
+				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+					{Array.from({ length: 4 }).map((_, i) => (
+						<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
+					))}
+				</Box>
+			) : packs.length === 0 ? (
+				<Typography color="grey.600">{tHome('search.noResults')}</Typography>
+			) : variant === 'cards' ? (
+				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+					{packs.map((p) => (
+						<SongVariantCard key={p.packGuid} data={p} dense sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
+					))}
+				</Box>
+			) : (
+				<Box sx={{ display: 'flex', flexDirection: 'column' }}>
+					{packs.map((p) => (
+						<Clickable key={p.packGuid}>
+							<Link to="variant" params={parseVariantAlias(p.packAlias)}>
+								<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25, borderBottom: '1px solid', borderColor: 'grey.200' }}>
+									<Typography strong noWrap sx={{ flex: 1 }}>
+										{p.title}
+									</Typography>
+									<ChevronRightRounded fontSize="small" sx={{ color: 'grey.300' }} />
+								</Box>
+							</Link>
+						</Clickable>
+					))}
+				</Box>
+			)}
 		</Box>
 	)
 }

--- a/src/app/components/HomeMobile.tsx
+++ b/src/app/components/HomeMobile.tsx
@@ -144,7 +144,7 @@ export default function HomeMobile({
 							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
 					  ))
 					: rec.slice(0, 5).map((s) => (
-							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1 }} />
+							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
 					  ))}
 			</Box>
 		</Box>

--- a/src/app/components/HomeMobile.tsx
+++ b/src/app/components/HomeMobile.tsx
@@ -1,0 +1,355 @@
+'use client'
+
+import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
+import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
+import { Box, Clickable, Typography, useTheme } from '@/common/ui'
+import { alpha } from '@/common/ui/mui'
+import { Link } from '@/common/ui/Link/Link'
+import { Skeleton } from '@/common/ui/mui/Skeleton'
+import { SongVariantCard } from '@/common/ui/SongCard'
+import { TextField } from '@/common/ui/TextField'
+import useAuth from '@/hooks/auth/useAuth'
+import { getSmartDateAgoString } from '@/tech/date/date.tech'
+import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
+import {
+	ChevronRightRounded,
+	HomeOutlined,
+	HomeRounded,
+	LibraryMusicOutlined,
+	LibraryMusicRounded,
+	LoginRounded,
+	PersonOutlineRounded,
+	PersonRounded,
+	SearchRounded,
+} from '@mui/icons-material'
+import { useTranslations } from 'next-intl'
+import { ReactNode } from 'react'
+import SearchedSongsList from './components/SearchedSongsList'
+
+const PAGE_MAX_WIDTH = 480
+const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
+const TAB_BAR = 'calc(env(safe-area-inset-bottom) + 64px)'
+const CONTENT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 176px)'
+
+// the chosen "deep soft" white → grey wash (demo variant 4)
+const WASH_HEIGHT = 400
+const WASH_SOLID_STOP = 25
+const WASH_GREY_STOP = 100
+
+type HomeMobileProps = {
+	searchInputValue: string
+	onSearchValueChange: (value: string) => void
+	searchString: string | null
+	smartSearch: boolean
+}
+
+/**
+ * Native-feeling mobile home: a grey canvas with a soft white → grey wash at
+ * the top, white "recommended" cards floating on the grey, a quiet "last
+ * added" list, a docked search in the thumb zone and a bottom tab bar. The
+ * desktop layout stays in HomeDesktop; this component owns the phone view.
+ */
+export default function HomeMobile({
+	searchInputValue,
+	onSearchValueChange,
+	searchString,
+	smartSearch,
+}: HomeMobileProps) {
+	const theme = useTheme()
+	const tHome = useTranslations('home')
+	const tNav = useTranslations('navigation')
+	const tSearch = useTranslations('search')
+	const { isLoggedIn } = useAuth()
+
+	const recommended = useRecommendedSongs()
+	const lastAdded = useLastAddedSongs()
+	const rec = recommended.data
+	const last = lastAdded.data
+	const loading = recommended.isLoading || lastAdded.isLoading
+
+	const loggedIn = isLoggedIn()
+	const searching = searchInputValue.trim().length > 0
+
+	// ---- header ------------------------------------------------------
+
+	const accountButton = (
+		<Box
+			aria-label={loggedIn ? tNav('account') : tNav('login')}
+			sx={{ width: 42, height: 42, borderRadius: 10, bgcolor: 'grey.100', color: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+		>
+			{loggedIn ? <PersonRounded fontSize="small" /> : <LoginRounded fontSize="small" />}
+		</Box>
+	)
+
+	const header = (
+		<Box
+			sx={{
+				paddingX: 2.5,
+				paddingTop: 'calc(env(safe-area-inset-top) + 32px)',
+				paddingBottom: 0.5,
+				display: 'flex',
+				justifyContent: 'space-between',
+				alignItems: 'end',
+			}}
+		>
+			<Box>
+				<Typography small color="grey.700">
+					{tHome('hero.lead')}
+				</Typography>
+				<Typography variant="h3" strong={800}>
+					{tHome('hero.title')}
+				</Typography>
+			</Box>
+			<Clickable tooltip={loggedIn ? tNav('account') : tNav('login')}>
+				{loggedIn ? (
+					<Link to="account" params={{}}>
+						{accountButton}
+					</Link>
+				) : (
+					<Link to="login" params={{ previousPage: '', message: '' }}>
+						{accountButton}
+					</Link>
+				)}
+			</Clickable>
+		</Box>
+	)
+
+	const label = (text: string, action?: ReactNode) => (
+		<Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, paddingX: 0.5 }}>
+			<Typography small strong uppercase color="grey.700">
+				{text.replace(/:$/, '')}
+			</Typography>
+			{action}
+		</Box>
+	)
+
+	const browseAction = (
+		<Clickable>
+			<Link to="songsList" params={{ s: undefined }}>
+				<Typography small strong uppercase color="primary.main">
+					{tHome('allList.browse')}
+				</Typography>
+			</Link>
+		</Clickable>
+	)
+
+	// ---- picks: white cards floating on the grey canvas --------------
+
+	const picks = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+			{label(tHome('recommended.idea'), browseAction)}
+			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+				{loading
+					? Array.from({ length: 4 }).map((_, i) => (
+							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
+					  ))
+					: rec.slice(0, 5).map((s) => (
+							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1 }} />
+					  ))}
+			</Box>
+		</Box>
+	)
+
+	// ---- recent: quiet airy list so it recedes -----------------------
+
+	const dateOf = (publishedAt?: Date | null) => (publishedAt ? getSmartDateAgoString(publishedAt) : '')
+
+	const recentInner = loading ? (
+		Array.from({ length: 4 }).map((_, i) => (
+			<Skeleton key={i} variant="rounded" sx={{ height: 32, borderRadius: 1, bgcolor: 'grey.200' }} />
+		))
+	) : (
+		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+			{last.slice(0, 5).map((s) => (
+				<Clickable key={s.packGuid}>
+					<Link to="variant" params={parseVariantAlias(s.packAlias)}>
+						<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1 }}>
+							<Typography color="grey.700" noWrap sx={{ flex: 1 }}>
+								{s.title}
+							</Typography>
+							<Typography small color="grey.400" noWrap>
+								{dateOf(s.publishedAt)}
+							</Typography>
+							<ChevronRightRounded fontSize="small" sx={{ color: 'grey.300' }} />
+						</Box>
+					</Link>
+				</Clickable>
+			))}
+		</Box>
+	)
+
+	const recent = (
+		<Box sx={{ paddingX: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+			{label(tHome('lastAdded.title'))}
+			{recentInner}
+		</Box>
+	)
+
+	// ---- search results (when the docked search has text) ------------
+
+	const results = (
+		<Box sx={{ paddingX: 2.5 }}>
+			{searchString ? (
+				<SearchedSongsList searchString={searchString} useSmartSearch={smartSearch} dense />
+			) : null}
+		</Box>
+	)
+
+	// ---- docked search: buttonless field with a primary gradient border
+
+	const search = (
+		<Box
+			component="form"
+			onSubmit={(e) => {
+				e.preventDefault()
+				;(e.currentTarget.querySelector('input') as HTMLInputElement | null)?.blur()
+			}}
+			sx={{
+				background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
+				borderRadius: 2,
+				padding: '2px',
+				boxShadow: 2,
+			}}
+		>
+			<Box
+				sx={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 1,
+					bgcolor: 'background.paper',
+					borderRadius: 1.75,
+					paddingX: 1.75,
+					paddingY: 1.25,
+					minWidth: 0,
+				}}
+			>
+				<SearchRounded sx={{ color: 'grey.500', fontSize: 20 }} />
+				<Box sx={{ flex: 1, minWidth: 0 }}>
+					<TextField value={searchInputValue} onChange={onSearchValueChange} placeholder={tSearch('searchByTitleOrText')} />
+				</Box>
+			</Box>
+		</Box>
+	)
+
+	const heroBg = `linear-gradient(to bottom, ${theme.palette.common.white} 0%, ${theme.palette.common.white} ${WASH_SOLID_STOP}%, ${theme.palette.grey[100]} ${WASH_GREY_STOP}%)`
+
+	return (
+		<Box
+			sx={{
+				// full-bleed: escape the SmartPage padded wrapper and the toolbar spacer
+				width: '100vw',
+				marginLeft: 'calc(50% - 50vw)',
+				marginTop: `calc(-1 * ${TOOLBAR_SPACER})`,
+				minHeight: '100dvh',
+				bgcolor: 'grey.300',
+				display: 'flex',
+				justifyContent: 'center',
+			}}
+		>
+			<Box
+				sx={{
+					width: '100%',
+					maxWidth: PAGE_MAX_WIDTH,
+					minWidth: 0,
+					minHeight: '100dvh',
+					bgcolor: 'grey.100', // the grey canvas that white cards float on
+					display: 'flex',
+					flexDirection: 'column',
+					boxShadow: 3,
+					position: 'relative',
+					overflow: 'hidden',
+				}}
+			>
+				{/* soft white → grey wash behind the top; fades out inside the picks */}
+				<Box
+					sx={{
+						position: 'absolute',
+						top: 0,
+						left: 0,
+						right: 0,
+						height: `calc(env(safe-area-inset-top) + ${WASH_HEIGHT}px)`,
+						background: heroBg,
+						zIndex: 0,
+						pointerEvents: 'none',
+					}}
+				/>
+				<Box sx={{ position: 'relative', zIndex: 1 }}>
+					{header}
+					{searching ? (
+						<Box sx={{ paddingTop: 2, paddingBottom: CONTENT_CLEARANCE }}>{results}</Box>
+					) : (
+						<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2, paddingBottom: CONTENT_CLEARANCE }}>
+							{picks}
+							{recent}
+						</Box>
+					)}
+				</Box>
+
+				{/* ===== SEARCH: docked above the tab bar (thumb zone) ===== */}
+				<Box
+					sx={{
+						position: 'fixed',
+						bottom: TAB_BAR,
+						left: '50%',
+						transform: 'translateX(-50%)',
+						width: '100%',
+						maxWidth: PAGE_MAX_WIDTH,
+						paddingX: 2.5,
+						paddingBottom: 1.5,
+						boxSizing: 'border-box',
+						zIndex: 10,
+					}}
+				>
+					{search}
+				</Box>
+
+				{/* ===================== BOTTOM TAB BAR ===================== */}
+				<Box
+					sx={{
+						position: 'fixed',
+						bottom: 0,
+						left: '50%',
+						transform: 'translateX(-50%)',
+						width: '100%',
+						maxWidth: PAGE_MAX_WIDTH,
+						bgcolor: alpha(theme.palette.background.paper, 0.85),
+						backdropFilter: 'blur(12px)',
+						borderTop: '1px solid',
+						borderColor: 'grey.300',
+						display: 'flex',
+						paddingBottom: 'env(safe-area-inset-bottom)',
+						zIndex: 10,
+					}}
+				>
+					<Link to="home" params={{ hledat: undefined }} style={{ flex: 1 }}>
+						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active />
+					</Link>
+					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
+						<TabItem icon={<LibraryMusicOutlined />} activeIcon={<LibraryMusicRounded />} label={tNav('songs')} />
+					</Link>
+					<Link to={loggedIn ? 'account' : 'login'} params={loggedIn ? {} : { previousPage: '', message: '' }} style={{ flex: 1 }}>
+						<TabItem icon={<PersonOutlineRounded />} activeIcon={<PersonRounded />} label={tNav('account')} />
+					</Link>
+				</Box>
+			</Box>
+		</Box>
+	)
+}
+
+type TabItemProps = {
+	icon: JSX.Element
+	activeIcon?: JSX.Element
+	label: string
+	active?: boolean
+}
+
+function TabItem({ icon, activeIcon, label, active }: TabItemProps) {
+	return (
+		<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, paddingY: 1, color: active ? 'primary.main' : 'grey.700' }}>
+			{active ? activeIcon ?? icon : icon}
+			<Typography small strong={active ? 700 : 400}>
+				{label}
+			</Typography>
+		</Box>
+	)
+}

--- a/src/app/components/HomeMobile.tsx
+++ b/src/app/components/HomeMobile.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { SearchSongDto } from '@/api/dtos/song/song.search.dto'
 import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
 import { Box, Clickable, Typography, useTheme } from '@/common/ui'
@@ -9,12 +10,12 @@ import { Skeleton } from '@/common/ui/mui/Skeleton'
 import { SongVariantCard } from '@/common/ui/SongCard'
 import { TextField } from '@/common/ui/TextField'
 import useAuth from '@/hooks/auth/useAuth'
-import { useUrlState } from '@/hooks/urlstate/useUrlState'
 import useSongSearch from '@/hooks/song/useSongSearch'
-import { SearchSongDto } from '@/api/dtos/song/song.search.dto'
-import { SearchKey } from '@/types/song/search.types'
+import usePagination from '@/hooks/usePagination'
+import { useIsInViewport } from '@/hooks/useIsInViewport'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
+import { SearchKey } from '@/types/song/search.types'
 import {
 	ChevronRightRounded,
 	HomeOutlined,
@@ -27,16 +28,15 @@ import {
 	SearchRounded,
 } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
-import { ReactNode, useEffect, useState } from 'react'
-import MainSearchInput from './components/MainSearchInput'
-import SearchedSongsList from './components/SearchedSongsList'
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
 const PAGE_MAX_WIDTH = 480
 const TOOLBAR_SPACER = '56px' // sticky TopBar spacer height (Toolbar.tsx)
 const TAB_BAR = 'calc(env(safe-area-inset-bottom) + 64px)'
 const CONTENT_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 176px)'
+const PREVIEW_LINES = 2 // lyric preview lines shown on the song cards
 
-// the chosen "deep soft" white → grey wash (demo variant 4)
+// the chosen "deep soft" white → grey wash
 const WASH_HEIGHT = 400
 const WASH_SOLID_STOP = 25
 const WASH_GREY_STOP = 100
@@ -51,8 +51,8 @@ type HomeMobileProps = {
 /**
  * Native-feeling mobile home: a grey canvas with a soft white → grey wash at
  * the top, white "recommended" cards floating on the grey, a quiet "last
- * added" list, a docked search in the thumb zone and a bottom tab bar. The
- * desktop layout stays in HomeDesktop; this component owns the phone view.
+ * added" list, a docked search in the thumb zone and a blue bottom tab bar.
+ * The desktop layout stays in HomeDesktop; this component owns the phone view.
  */
 export default function HomeMobile({
 	searchInputValue,
@@ -74,20 +74,6 @@ export default function HomeMobile({
 
 	const loggedIn = isLoggedIn()
 	const searching = searchInputValue.trim().length > 0
-
-	// temporary variant switches (remove once a look is chosen):
-	//   ?sf= search field   1 = white gradient-border (default) · 2 = house MainSearchInput
-	//   ?sr= search results 2 = white cards (default) · 1 = shared list · 3 = quiet list
-	//   ?cl= card lines     2 = two preview lines (default) · 1 = single line
-	//   ?tb= tab bar        1 = white blur (default) · 2 = blue primary gradient
-	const [sfParam] = useUrlState('sf')
-	const [srParam] = useUrlState('sr')
-	const [clParam] = useUrlState('cl')
-	const [tbParam] = useUrlState('tb')
-	const sf = Number(sfParam) === 2 ? 2 : 1
-	const sr = Number(srParam) === 1 ? 1 : Number(srParam) === 3 ? 3 : 2
-	const previewLines = Number(clParam) === 1 ? 1 : 2
-	const blueTab = Number(tbParam) === 2
 
 	// ---- header ------------------------------------------------------
 
@@ -160,10 +146,10 @@ export default function HomeMobile({
 			<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
 				{loading
 					? Array.from({ length: 4 }).map((_, i) => (
-							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
+							<Skeleton key={i} variant="rounded" sx={{ height: 72, borderRadius: 2, bgcolor: 'grey.200' }} />
 					  ))
 					: rec.slice(0, 5).map((s) => (
-							<SongVariantCard key={s.packGuid} data={s} dense previewLines={previewLines} sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
+							<SongVariantCard key={s.packGuid} data={s} dense previewLines={PREVIEW_LINES} sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
 					  ))}
 			</Box>
 		</Box>
@@ -204,23 +190,9 @@ export default function HomeMobile({
 		</Box>
 	)
 
-	// ---- search results (when the docked search has text) ------------
-
-	const results = (
-		<Box sx={{ paddingX: 2.5 }}>
-			{searchString ? (
-				sr === 1 ? (
-					<SearchedSongsList searchString={searchString} useSmartSearch={smartSearch} dense />
-				) : (
-					<MobileSearchResults searchString={searchString} smartSearch={smartSearch} variant={sr === 2 ? 'cards' : 'list'} previewLines={previewLines} />
-				)
-			) : null}
-		</Box>
-	)
-
 	// ---- docked search: buttonless field with a primary gradient border
 
-	const handmadeSearch = (
+	const search = (
 		<Box
 			component="form"
 			onSubmit={(e) => {
@@ -253,15 +225,6 @@ export default function HomeMobile({
 			</Box>
 		</Box>
 	)
-
-	const search =
-		sf === 2 ? (
-			<Box sx={{ boxShadow: 2, borderRadius: '0.6rem' }}>
-				<MainSearchInput gradientBorder value={searchInputValue} onChange={onSearchValueChange} autoFocus={false} smartSearch={smartSearch} />
-			</Box>
-		) : (
-			handmadeSearch
-		)
 
 	const heroBg = `linear-gradient(to bottom, ${theme.palette.common.white} 0%, ${theme.palette.common.white} ${WASH_SOLID_STOP}%, ${theme.palette.grey[100]} ${WASH_GREY_STOP}%)`
 
@@ -308,7 +271,9 @@ export default function HomeMobile({
 				<Box sx={{ position: 'relative', zIndex: 1 }}>
 					{header}
 					{searching ? (
-						<Box sx={{ paddingTop: 2, paddingBottom: CONTENT_CLEARANCE }}>{results}</Box>
+						<Box sx={{ paddingX: 2.5, paddingTop: 2, paddingBottom: CONTENT_CLEARANCE }}>
+							{searchString ? <MobileSearchResults searchString={searchString} smartSearch={smartSearch} /> : null}
+						</Box>
 					) : (
 						<Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, paddingTop: 2, paddingBottom: CONTENT_CLEARANCE }}>
 							{picks}
@@ -344,22 +309,20 @@ export default function HomeMobile({
 						transform: 'translateX(-50%)',
 						width: '100%',
 						maxWidth: PAGE_MAX_WIDTH,
-						...(blueTab
-							? { background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})` }
-							: { bgcolor: alpha(theme.palette.background.paper, 0.85), backdropFilter: 'blur(12px)', borderTop: '1px solid', borderColor: 'grey.300' }),
+						background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
 						display: 'flex',
 						paddingBottom: 'env(safe-area-inset-bottom)',
 						zIndex: 10,
 					}}
 				>
 					<Link to="home" params={{ hledat: undefined }} style={{ flex: 1 }}>
-						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active blue={blueTab} />
+						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active />
 					</Link>
 					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
-						<TabItem icon={<LibraryMusicOutlined />} activeIcon={<LibraryMusicRounded />} label={tNav('songs')} blue={blueTab} />
+						<TabItem icon={<LibraryMusicOutlined />} activeIcon={<LibraryMusicRounded />} label={tNav('songs')} />
 					</Link>
 					<Link to={loggedIn ? 'account' : 'login'} params={loggedIn ? {} : { previousPage: '', message: '' }} style={{ flex: 1 }}>
-						<TabItem icon={<PersonOutlineRounded />} activeIcon={<PersonRounded />} label={tNav('account')} blue={blueTab} />
+						<TabItem icon={<PersonOutlineRounded />} activeIcon={<PersonRounded />} label={tNav('account')} />
 					</Link>
 				</Box>
 			</Box>
@@ -372,18 +335,13 @@ type TabItemProps = {
 	activeIcon?: JSX.Element
 	label: string
 	active?: boolean
-	blue?: boolean
 }
 
-function TabItem({ icon, activeIcon, label, active, blue }: TabItemProps) {
+// Tab item for the blue (primary-gradient) bottom bar: white icon/label,
+// dimmed when inactive.
+function TabItem({ icon, activeIcon, label, active }: TabItemProps) {
 	const theme = useTheme()
-	const color = blue
-		? active
-			? theme.palette.common.white
-			: alpha(theme.palette.common.white, 0.72)
-		: active
-		? theme.palette.primary.main
-		: theme.palette.grey[700]
+	const color = active ? theme.palette.common.white : alpha(theme.palette.common.white, 0.72)
 	return (
 		<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, paddingY: 1, color }}>
 			{active ? activeIcon ?? icon : icon}
@@ -395,45 +353,45 @@ function TabItem({ icon, activeIcon, label, active, blue }: TabItemProps) {
 }
 
 /**
- * Variant renderer for the search results so we can compare looks:
- *  - 'cards' — white floating cards, matching the recommended picks
- *  - 'list'  — a quiet title-only list with dividers
- * (variant 'shared' keeps the existing SearchedSongsList; handled by the caller)
+ * Search results as white floating cards (matching the recommended picks),
+ * paginated with infinite scroll — same data flow as the shared
+ * SearchedSongsList, just rendered in the mobile home's card language.
  */
-function MobileSearchResults({
-	searchString,
-	smartSearch,
-	variant,
-	previewLines,
-}: {
-	searchString: string
-	smartSearch: boolean
-	variant: 'cards' | 'list'
-	previewLines: number
-}) {
+function MobileSearchResults({ searchString, smartSearch }: { searchString: string; smartSearch: boolean }) {
 	const tHome = useTranslations('home')
 	const searchSongs = useSongSearch()
-	const [songs, setSongs] = useState<SearchSongDto[]>([])
+	const loadNextRef = useRef<HTMLDivElement>(null)
 	const [loading, setLoading] = useState(true)
+	const [enableLoadNext, setEnableLoadNext] = useState(false)
+
+	const func = useCallback(
+		(page: number, resolve: (a: SearchSongDto[]) => void) => {
+			searchSongs(searchString as SearchKey, { page, useSmartSearch: smartSearch })
+				.then((data) => {
+					setLoading(false)
+					resolve(data)
+				})
+				.catch(() => {
+					setLoading(false)
+					resolve([])
+				})
+		},
+		[searchString, smartSearch, searchSongs]
+	)
+
+	const { nextPage: loadNext, loadPage, data: songs, nextExists } = usePagination<SearchSongDto>(func)
 
 	useEffect(() => {
-		let active = true
+		setEnableLoadNext(false)
 		setLoading(true)
-		searchSongs(searchString as SearchKey, { page: 0, useSmartSearch: smartSearch })
-			.then((data) => {
-				if (!active) return
-				setSongs(data)
-				setLoading(false)
-			})
-			.catch(() => {
-				if (!active) return
-				setSongs([])
-				setLoading(false)
-			})
-		return () => {
-			active = false
-		}
-	}, [searchString, smartSearch, searchSongs])
+		loadPage(0, true).finally(() => setEnableLoadNext(true))
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [searchString, smartSearch])
+
+	useIsInViewport(loadNextRef, '200px', (intersecting) => {
+		if (!enableLoadNext || !intersecting) return
+		if (songs.length > 0 && nextExists) loadNext()
+	})
 
 	const packs = songs.flatMap((s) => s.found)
 
@@ -442,36 +400,22 @@ function MobileSearchResults({
 			<Typography small strong uppercase color="grey.700" sx={{ paddingX: 0.5 }}>
 				{tHome('search.resultsTitle').replace(/:$/, '')}
 			</Typography>
-			{loading ? (
-				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-					{Array.from({ length: 4 }).map((_, i) => (
-						<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
-					))}
-				</Box>
-			) : packs.length === 0 ? (
-				<Typography color="grey.600">{tHome('search.noResults')}</Typography>
-			) : variant === 'cards' ? (
+			{packs.length > 0 ? (
 				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
 					{packs.map((p) => (
-						<SongVariantCard key={p.packGuid} data={p} dense previewLines={previewLines} sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
+						<SongVariantCard key={p.packGuid} data={p} dense previewLines={PREVIEW_LINES} sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
+					))}
+				</Box>
+			) : loading ? (
+				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+					{Array.from({ length: 4 }).map((_, i) => (
+						<Skeleton key={i} variant="rounded" sx={{ height: 72, borderRadius: 2, bgcolor: 'grey.200' }} />
 					))}
 				</Box>
 			) : (
-				<Box sx={{ display: 'flex', flexDirection: 'column' }}>
-					{packs.map((p) => (
-						<Clickable key={p.packGuid}>
-							<Link to="variant" params={parseVariantAlias(p.packAlias)}>
-								<Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, paddingY: 1.25, borderBottom: '1px solid', borderColor: 'grey.200' }}>
-									<Typography strong noWrap sx={{ flex: 1 }}>
-										{p.title}
-									</Typography>
-									<ChevronRightRounded fontSize="small" sx={{ color: 'grey.300' }} />
-								</Box>
-							</Link>
-						</Clickable>
-					))}
-				</Box>
+				<Typography color="grey.600">{tHome('search.noResults')}</Typography>
 			)}
+			<Box ref={loadNextRef} sx={{ height: 1 }} />
 		</Box>
 	)
 }

--- a/src/app/components/HomeMobile.tsx
+++ b/src/app/components/HomeMobile.tsx
@@ -78,13 +78,16 @@ export default function HomeMobile({
 	// temporary variant switches (remove once a look is chosen):
 	//   ?sf= search field   1 = white gradient-border (default) · 2 = house MainSearchInput
 	//   ?sr= search results 2 = white cards (default) · 1 = shared list · 3 = quiet list
-	//   ?cl= card lines     1 = single preview line (default) · 2 = two lines
+	//   ?cl= card lines     2 = two preview lines (default) · 1 = single line
+	//   ?tb= tab bar        1 = white blur (default) · 2 = blue primary gradient
 	const [sfParam] = useUrlState('sf')
 	const [srParam] = useUrlState('sr')
 	const [clParam] = useUrlState('cl')
+	const [tbParam] = useUrlState('tb')
 	const sf = Number(sfParam) === 2 ? 2 : 1
 	const sr = Number(srParam) === 1 ? 1 : Number(srParam) === 3 ? 3 : 2
-	const previewLines = Number(clParam) === 2 ? 2 : 1
+	const previewLines = Number(clParam) === 1 ? 1 : 2
+	const blueTab = Number(tbParam) === 2
 
 	// ---- header ------------------------------------------------------
 
@@ -341,23 +344,22 @@ export default function HomeMobile({
 						transform: 'translateX(-50%)',
 						width: '100%',
 						maxWidth: PAGE_MAX_WIDTH,
-						bgcolor: alpha(theme.palette.background.paper, 0.85),
-						backdropFilter: 'blur(12px)',
-						borderTop: '1px solid',
-						borderColor: 'grey.300',
+						...(blueTab
+							? { background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})` }
+							: { bgcolor: alpha(theme.palette.background.paper, 0.85), backdropFilter: 'blur(12px)', borderTop: '1px solid', borderColor: 'grey.300' }),
 						display: 'flex',
 						paddingBottom: 'env(safe-area-inset-bottom)',
 						zIndex: 10,
 					}}
 				>
 					<Link to="home" params={{ hledat: undefined }} style={{ flex: 1 }}>
-						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active />
+						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active blue={blueTab} />
 					</Link>
 					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
-						<TabItem icon={<LibraryMusicOutlined />} activeIcon={<LibraryMusicRounded />} label={tNav('songs')} />
+						<TabItem icon={<LibraryMusicOutlined />} activeIcon={<LibraryMusicRounded />} label={tNav('songs')} blue={blueTab} />
 					</Link>
 					<Link to={loggedIn ? 'account' : 'login'} params={loggedIn ? {} : { previousPage: '', message: '' }} style={{ flex: 1 }}>
-						<TabItem icon={<PersonOutlineRounded />} activeIcon={<PersonRounded />} label={tNav('account')} />
+						<TabItem icon={<PersonOutlineRounded />} activeIcon={<PersonRounded />} label={tNav('account')} blue={blueTab} />
 					</Link>
 				</Box>
 			</Box>
@@ -370,11 +372,20 @@ type TabItemProps = {
 	activeIcon?: JSX.Element
 	label: string
 	active?: boolean
+	blue?: boolean
 }
 
-function TabItem({ icon, activeIcon, label, active }: TabItemProps) {
+function TabItem({ icon, activeIcon, label, active, blue }: TabItemProps) {
+	const theme = useTheme()
+	const color = blue
+		? active
+			? theme.palette.common.white
+			: alpha(theme.palette.common.white, 0.72)
+		: active
+		? theme.palette.primary.main
+		: theme.palette.grey[700]
 	return (
-		<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, paddingY: 1, color: active ? 'primary.main' : 'grey.700' }}>
+		<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, paddingY: 1, color }}>
 			{active ? activeIcon ?? icon : icon}
 			<Typography small strong={active ? 700 : 400}>
 				{label}

--- a/src/app/components/HomeMobile.tsx
+++ b/src/app/components/HomeMobile.tsx
@@ -77,11 +77,14 @@ export default function HomeMobile({
 
 	// temporary variant switches (remove once a look is chosen):
 	//   ?sf= search field   1 = white gradient-border (default) · 2 = house MainSearchInput
-	//   ?sr= search results 1 = shared list (default) · 2 = white cards · 3 = quiet list
+	//   ?sr= search results 2 = white cards (default) · 1 = shared list · 3 = quiet list
+	//   ?cl= card lines     1 = single preview line (default) · 2 = two lines
 	const [sfParam] = useUrlState('sf')
 	const [srParam] = useUrlState('sr')
+	const [clParam] = useUrlState('cl')
 	const sf = Number(sfParam) === 2 ? 2 : 1
-	const sr = Number(srParam) === 2 ? 2 : Number(srParam) === 3 ? 3 : 1
+	const sr = Number(srParam) === 1 ? 1 : Number(srParam) === 3 ? 3 : 2
+	const previewLines = Number(clParam) === 2 ? 2 : 1
 
 	// ---- header ------------------------------------------------------
 
@@ -157,7 +160,7 @@ export default function HomeMobile({
 							<Skeleton key={i} variant="rounded" sx={{ height: 56, borderRadius: 2, bgcolor: 'grey.200' }} />
 					  ))
 					: rec.slice(0, 5).map((s) => (
-							<SongVariantCard key={s.packGuid} data={s} dense sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
+							<SongVariantCard key={s.packGuid} data={s} dense previewLines={previewLines} sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
 					  ))}
 			</Box>
 		</Box>
@@ -206,7 +209,7 @@ export default function HomeMobile({
 				sr === 1 ? (
 					<SearchedSongsList searchString={searchString} useSmartSearch={smartSearch} dense />
 				) : (
-					<MobileSearchResults searchString={searchString} smartSearch={smartSearch} variant={sr === 2 ? 'cards' : 'list'} />
+					<MobileSearchResults searchString={searchString} smartSearch={smartSearch} variant={sr === 2 ? 'cards' : 'list'} previewLines={previewLines} />
 				)
 			) : null}
 		</Box>
@@ -390,10 +393,12 @@ function MobileSearchResults({
 	searchString,
 	smartSearch,
 	variant,
+	previewLines,
 }: {
 	searchString: string
 	smartSearch: boolean
 	variant: 'cards' | 'list'
+	previewLines: number
 }) {
 	const tHome = useTranslations('home')
 	const searchSongs = useSongSearch()
@@ -437,7 +442,7 @@ function MobileSearchResults({
 			) : variant === 'cards' ? (
 				<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
 					{packs.map((p) => (
-						<SongVariantCard key={p.packGuid} data={p} dense sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
+						<SongVariantCard key={p.packGuid} data={p} dense previewLines={previewLines} sx={{ bgcolor: 'background.paper', boxShadow: 1, '&:hover': { bgcolor: 'background.paper' } }} />
 					))}
 				</Box>
 			) : (

--- a/src/app/components/HomeMobile.tsx
+++ b/src/app/components/HomeMobile.tsx
@@ -3,8 +3,8 @@
 import { SearchSongDto } from '@/api/dtos/song/song.search.dto'
 import useLastAddedSongs from '@/app/components/components/LastAddedSongsList/hooks/useLastAddedSongs'
 import useRecommendedSongs from '@/app/components/components/RecommendedSongsList/hooks/useRecommendedSongs'
+import MobileAppTabBar from '@/common/components/MobileAppTabBar/MobileAppTabBar'
 import { Box, Clickable, Typography, useTheme } from '@/common/ui'
-import { alpha } from '@/common/ui/mui'
 import { Link } from '@/common/ui/Link/Link'
 import { Skeleton } from '@/common/ui/mui/Skeleton'
 import { SongVariantCard } from '@/common/ui/SongCard'
@@ -16,17 +16,7 @@ import { useIsInViewport } from '@/hooks/useIsInViewport'
 import { getSmartDateAgoString } from '@/tech/date/date.tech'
 import { parseVariantAlias } from '@/tech/song/variant/variant.utils'
 import { SearchKey } from '@/types/song/search.types'
-import {
-	ChevronRightRounded,
-	HomeOutlined,
-	HomeRounded,
-	LibraryMusicOutlined,
-	LibraryMusicRounded,
-	LoginRounded,
-	PersonOutlineRounded,
-	PersonRounded,
-	SearchRounded,
-} from '@mui/icons-material'
+import { ChevronRightRounded, LoginRounded, PersonRounded, SearchRounded } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
@@ -301,53 +291,8 @@ export default function HomeMobile({
 				</Box>
 
 				{/* ===================== BOTTOM TAB BAR ===================== */}
-				<Box
-					sx={{
-						position: 'fixed',
-						bottom: 0,
-						left: '50%',
-						transform: 'translateX(-50%)',
-						width: '100%',
-						maxWidth: PAGE_MAX_WIDTH,
-						background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
-						display: 'flex',
-						paddingBottom: 'env(safe-area-inset-bottom)',
-						zIndex: 10,
-					}}
-				>
-					<Link to="home" params={{ hledat: undefined }} style={{ flex: 1 }}>
-						<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active />
-					</Link>
-					<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
-						<TabItem icon={<LibraryMusicOutlined />} activeIcon={<LibraryMusicRounded />} label={tNav('songs')} />
-					</Link>
-					<Link to={loggedIn ? 'account' : 'login'} params={loggedIn ? {} : { previousPage: '', message: '' }} style={{ flex: 1 }}>
-						<TabItem icon={<PersonOutlineRounded />} activeIcon={<PersonRounded />} label={tNav('account')} />
-					</Link>
-				</Box>
+				<MobileAppTabBar />
 			</Box>
-		</Box>
-	)
-}
-
-type TabItemProps = {
-	icon: JSX.Element
-	activeIcon?: JSX.Element
-	label: string
-	active?: boolean
-}
-
-// Tab item for the blue (primary-gradient) bottom bar: white icon/label,
-// dimmed when inactive.
-function TabItem({ icon, activeIcon, label, active }: TabItemProps) {
-	const theme = useTheme()
-	const color = active ? theme.palette.common.white : alpha(theme.palette.common.white, 0.72)
-	return (
-		<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, paddingY: 1, color }}>
-			{active ? activeIcon ?? icon : icon}
-			<Typography small strong={active ? 700 : 400}>
-				{label}
-			</Typography>
 		</Box>
 	)
 }

--- a/src/app/components/components/MainSearchInput.tsx
+++ b/src/app/components/components/MainSearchInput.tsx
@@ -33,6 +33,7 @@ type MainSearchInputProps = {
 	onChange: (value: string) => void
 	smartSearch?: boolean
 	onSmartSearchChange?: (value: boolean) => void
+	autoFocus?: boolean
 }
 
 export const MAIN_SEARCH_EVENT_NAME = 'search_event_5jh14'
@@ -91,7 +92,7 @@ export default function MainSearchInput(props: MainSearchInputProps) {
 				<SearchInput
 					placeholder={t('searchByTitleOrText')}
 					onChange={(e) => props.onChange(e.target.value)}
-					autoFocus
+					autoFocus={props.autoFocus ?? true}
 					value={props.value}
 					inputRef={inputRef}
 					inputProps={{ 'data-testid': 'main-search-input' }}

--- a/src/app/components/components/MainSearchInput.tsx
+++ b/src/app/components/components/MainSearchInput.tsx
@@ -43,6 +43,16 @@ export default function MainSearchInput(props: MainSearchInputProps) {
 	const t = useTranslations('search')
 	const inputRef = useRef<HTMLInputElement>()
 
+	// Focus via effect instead of the DOM autofocus attribute: the first
+	// hydration render always mounts the desktop layout, so on phones the
+	// attribute would briefly grab focus (and pop the keyboard) before the
+	// phone layout replaces it. 700px = the phone breakpoint in HomeDesktop.
+	useEffect(() => {
+		if (!(props.autoFocus ?? true)) return
+		if (!window.matchMedia('(min-width: 700px)').matches) return
+		inputRef.current?.focus()
+	}, [])
+
 	const [earlyFocused, setEarlyFocused] = useState(false)
 	useChangeDelayer(
 		earlyFocused,
@@ -92,7 +102,6 @@ export default function MainSearchInput(props: MainSearchInputProps) {
 				<SearchInput
 					placeholder={t('searchByTitleOrText')}
 					onChange={(e) => props.onChange(e.target.value)}
-					autoFocus={props.autoFocus ?? true}
 					value={props.value}
 					inputRef={inputRef}
 					inputProps={{ 'data-testid': 'main-search-input' }}

--- a/src/app/components/components/RecommendedSongsList/RecommendedSongsList.tsx
+++ b/src/app/components/components/RecommendedSongsList/RecommendedSongsList.tsx
@@ -18,10 +18,12 @@ const GridContainer = styled(Grid)(({ theme }) => ({
 
 type RecommendedSongsListProps = {
 	listType?: SongListCardsProps['variant']
+	dense?: boolean
 }
 
 export default function RecommendedSongsList({
 	listType = 'row',
+	dense,
 }: RecommendedSongsListProps) {
 	const theme = useTheme()
 	const tHome = useTranslations('home')
@@ -39,7 +41,7 @@ export default function RecommendedSongsList({
 				width: '100%',
 			}}
 		>
-			<Typography strong key={'idea'}>
+			<Typography strong variant={dense ? 'h6' : 'normal'} key={'idea'}>
 				{tHome('recommended.idea')}
 			</Typography>
 
@@ -71,6 +73,7 @@ export default function RecommendedSongsList({
 				<SongListCards
 					data={data.slice(0, 4)}
 					variant={listType}
+					dense={dense}
 					// properties={['SHOW_ADDED_BY_LOADER']}
 				/>
 			</GridContainer>

--- a/src/app/components/components/RecommendedSongsList/RecommendedSongsList.tsx
+++ b/src/app/components/components/RecommendedSongsList/RecommendedSongsList.tsx
@@ -34,6 +34,7 @@ export default function RecommendedSongsList({
 
 	return (
 		<ContainerGrid
+			direction="column"
 			sx={{
 				width: '100%',
 			}}

--- a/src/app/components/components/SearchedSongsList.tsx
+++ b/src/app/components/components/SearchedSongsList.tsx
@@ -19,12 +19,14 @@ import { SearchKey } from '@/types/song/search.types'
 interface SearchedSongsListProps {
 	searchString: string
 	useSmartSearch?: boolean
+	dense?: boolean
 }
 const controller = new AbortController()
 
 const SearchedSongsList = memo(function S({
 	searchString,
 	useSmartSearch,
+	dense,
 }: SearchedSongsListProps) {
 	const loadNextLevelRef = useRef(null)
 	const lastTrackedSearchRef = useRef('')
@@ -113,7 +115,7 @@ const SearchedSongsList = memo(function S({
 	return (
 		<ContainerGrid direction="column">
 			<>
-				<Typography strong key={'results'}>
+				<Typography strong variant={dense ? 'h6' : 'normal'} key={'results'}>
 					{tHome('search.resultsTitle')}
 				</Typography>
 
@@ -121,6 +123,7 @@ const SearchedSongsList = memo(function S({
 					<SmartSongListCards
 						data={songs}
 						key={'songlistcards'}
+						dense={dense}
 						properties={['SHOW_ADDED_BY_LOADER', 'SHOW_PRIVATE_LABEL']}
 					></SmartSongListCards>
 				)}

--- a/src/common/components/MobileAppTabBar/MobileAppTabBar.tsx
+++ b/src/common/components/MobileAppTabBar/MobileAppTabBar.tsx
@@ -16,6 +16,10 @@ import { usePathname } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 
 const PAGE_MAX_WIDTH = 480
+/** Width below which the mobile tab bar shows (and the top bar hides). */
+export const MOBILE_NAV_BREAKPOINT = 700
+/** Bottom clearance pages need so their content isn't hidden by the fixed bar. */
+export const MOBILE_NAV_CLEARANCE = 'calc(env(safe-area-inset-bottom) + 72px)'
 
 type ActiveTab = 'home' | 'songs' | 'account' | null
 
@@ -53,7 +57,7 @@ export default function MobileAppTabBar() {
 				display: 'flex',
 				paddingBottom: 'env(safe-area-inset-bottom)',
 				zIndex: 10,
-				[theme.breakpoints.up(700)]: { display: 'none' },
+				[theme.breakpoints.up(MOBILE_NAV_BREAKPOINT)]: { display: 'none' },
 			}}
 		>
 			<Link to="home" params={{ hledat: undefined }} style={{ flex: 1 }}>

--- a/src/common/components/MobileAppTabBar/MobileAppTabBar.tsx
+++ b/src/common/components/MobileAppTabBar/MobileAppTabBar.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { Box, Typography, useTheme } from '@/common/ui'
+import { Link } from '@/common/ui/Link/Link'
+import { alpha } from '@/common/ui/mui'
+import useAuth from '@/hooks/auth/useAuth'
+import {
+	HomeOutlined,
+	HomeRounded,
+	LibraryMusicOutlined,
+	LibraryMusicRounded,
+	PersonOutlineRounded,
+	PersonRounded,
+} from '@mui/icons-material'
+import { usePathname } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+
+const PAGE_MAX_WIDTH = 480
+
+type ActiveTab = 'home' | 'songs' | 'account' | null
+
+function activeTabFor(pathname: string | null): ActiveTab {
+	if (!pathname) return null
+	if (pathname === '/') return 'home'
+	if (pathname.startsWith('/seznam') || pathname.startsWith('/pisen')) return 'songs'
+	if (pathname.startsWith('/ucet')) return 'account'
+	return null
+}
+
+/**
+ * The app's mobile bottom navigation — a blue (primary-gradient) tab bar with
+ * Home / Songs / Account. Shown only on phones (CSS-hidden on desktop) and only
+ * on "app" pages that opt in (via the SmartPage `mobileTabBar` option, or by
+ * rendering it directly like the mobile home). Marketing pages keep the top bar.
+ */
+export default function MobileAppTabBar() {
+	const theme = useTheme()
+	const tNav = useTranslations('navigation')
+	const { isLoggedIn } = useAuth()
+	const active = activeTabFor(usePathname())
+	const loggedIn = isLoggedIn()
+
+	return (
+		<Box
+			sx={{
+				position: 'fixed',
+				bottom: 0,
+				left: '50%',
+				transform: 'translateX(-50%)',
+				width: '100%',
+				maxWidth: PAGE_MAX_WIDTH,
+				background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
+				display: 'flex',
+				paddingBottom: 'env(safe-area-inset-bottom)',
+				zIndex: 10,
+				[theme.breakpoints.up(700)]: { display: 'none' },
+			}}
+		>
+			<Link to="home" params={{ hledat: undefined }} style={{ flex: 1 }}>
+				<TabItem icon={<HomeOutlined />} activeIcon={<HomeRounded />} label={tNav('home')} active={active === 'home'} />
+			</Link>
+			<Link to="songsList" params={{ s: undefined }} style={{ flex: 1 }}>
+				<TabItem icon={<LibraryMusicOutlined />} activeIcon={<LibraryMusicRounded />} label={tNav('songs')} active={active === 'songs'} />
+			</Link>
+			<Link to={loggedIn ? 'account' : 'login'} params={loggedIn ? {} : { previousPage: '', message: '' }} style={{ flex: 1 }}>
+				<TabItem icon={<PersonOutlineRounded />} activeIcon={<PersonRounded />} label={tNav('account')} active={active === 'account'} />
+			</Link>
+		</Box>
+	)
+}
+
+type TabItemProps = {
+	icon: JSX.Element
+	activeIcon?: JSX.Element
+	label: string
+	active?: boolean
+}
+
+// White icon/label on the blue bar, dimmed when inactive.
+function TabItem({ icon, activeIcon, label, active }: TabItemProps) {
+	const theme = useTheme()
+	const color = active ? theme.palette.common.white : alpha(theme.palette.common.white, 0.72)
+	return (
+		<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, paddingY: 1, color }}>
+			{active ? activeIcon ?? icon : icon}
+			<Typography small strong={active ? 700 : 400}>
+				{label}
+			</Typography>
+		</Box>
+	)
+}

--- a/src/common/components/app/SmartPage/SmartPageInner.tsx
+++ b/src/common/components/app/SmartPage/SmartPageInner.tsx
@@ -1,7 +1,9 @@
 'use client'
 import { useFooter } from '@/common/components/Footer/hooks/useFooter'
+import MobileAppTabBar from '@/common/components/MobileAppTabBar/MobileAppTabBar'
 import { useToolbar } from '@/common/components/Toolbar/hooks/useToolbar'
 import { Box, useTheme } from '@/common/ui'
+import { useMediaQuery } from '@/common/ui/mui'
 import React, { useEffect, useMemo } from 'react'
 
 // type of dict or null for every option
@@ -22,6 +24,8 @@ export type SmartPageOptions = Nullable<{
 	middleWidth: boolean
 	topPadding: boolean
 	containLayout: boolean
+	/** App page: hide the top bar on mobile and show the bottom tab bar instead */
+	mobileTabBar: boolean
 }>
 
 const MIDDLE_WIDTH = 900
@@ -48,6 +52,7 @@ export const SmartPageInnerProvider = ({
 			middleWidth: false,
 			topPadding: false,
 			containLayout: false,
+			mobileTabBar: false,
 			...pageOptions,
 		}),
 		[pageOptions]
@@ -55,6 +60,8 @@ export const SmartPageInnerProvider = ({
 
 	const toolbar = useToolbar()
 	const footer = useFooter()
+	const theme = useTheme()
+	const phoneVersion = useMediaQuery(theme.breakpoints.down(700))
 
 	useEffect(() => {
 		if (options.transparentToolbar !== null)
@@ -74,7 +81,15 @@ export const SmartPageInnerProvider = ({
 
 		if (options.hideFooter !== null) footer.setShow(!options.hideFooter)
 	}, [options])
-	const theme = useTheme()
+
+	// App pages replace the top bar with the bottom tab bar on phones. Kept in a
+	// separate effect (runs after the options one) so it wins the setHidden race,
+	// and restored on leave so other pages get their top bar back.
+	useEffect(() => {
+		if (!options.mobileTabBar) return
+		toolbar.setHidden(phoneVersion)
+		return () => toolbar.setHidden(false)
+	}, [options.mobileTabBar, phoneVersion])
 
 	return (
 		<Box
@@ -105,9 +120,19 @@ export const SmartPageInnerProvider = ({
 							contain: 'layout',
 					  }
 					: {}),
+
+				// clear the fixed bottom tab bar on phones
+				...(options.mobileTabBar
+					? {
+							[theme.breakpoints.down(700)]: {
+								paddingBottom: 'calc(env(safe-area-inset-bottom) + 72px)',
+							},
+					  }
+					: {}),
 			}}
 		>
 			{children}
+			{options.mobileTabBar && <MobileAppTabBar />}
 		</Box>
 	)
 }

--- a/src/common/components/app/SmartPage/SmartPageInner.tsx
+++ b/src/common/components/app/SmartPage/SmartPageInner.tsx
@@ -1,6 +1,9 @@
 'use client'
 import { useFooter } from '@/common/components/Footer/hooks/useFooter'
-import MobileAppTabBar from '@/common/components/MobileAppTabBar/MobileAppTabBar'
+import MobileAppTabBar, {
+	MOBILE_NAV_BREAKPOINT,
+	MOBILE_NAV_CLEARANCE,
+} from '@/common/components/MobileAppTabBar/MobileAppTabBar'
 import { useToolbar } from '@/common/components/Toolbar/hooks/useToolbar'
 import { Box, useTheme } from '@/common/ui'
 import { useMediaQuery } from '@/common/ui/mui'
@@ -61,7 +64,7 @@ export const SmartPageInnerProvider = ({
 	const toolbar = useToolbar()
 	const footer = useFooter()
 	const theme = useTheme()
-	const phoneVersion = useMediaQuery(theme.breakpoints.down(700))
+	const phoneVersion = useMediaQuery(theme.breakpoints.down(MOBILE_NAV_BREAKPOINT))
 
 	useEffect(() => {
 		if (options.transparentToolbar !== null)
@@ -124,8 +127,8 @@ export const SmartPageInnerProvider = ({
 				// clear the fixed bottom tab bar on phones
 				...(options.mobileTabBar
 					? {
-							[theme.breakpoints.down(700)]: {
-								paddingBottom: 'calc(env(safe-area-inset-bottom) + 72px)',
+							[theme.breakpoints.down(MOBILE_NAV_BREAKPOINT)]: {
+								paddingBottom: MOBILE_NAV_CLEARANCE,
 							},
 					  }
 					: {}),

--- a/src/common/components/songLists/SongListCards/SmartSongListCards.tsx
+++ b/src/common/components/songLists/SongListCards/SmartSongListCards.tsx
@@ -13,6 +13,7 @@ type CommmonProps = {
 	data: SearchSongDto[]
 	properties?: ComponentProps<typeof SongVariantCard>['properties']
 	cardToLinkProps?: ComponentProps<typeof SongVariantCard>['toLinkProps']
+	dense?: boolean
 	onCardClick?: (data: BasicVariantPack) => void
 
 	// Selecting
@@ -82,6 +83,7 @@ export const SmartSongListCard = memo(function SongListCards({
 					packs={packs}
 					original={original}
 					flexibleHeight={flexibleHeight}
+					dense={props.dense}
 				/>
 			)
 		},
@@ -104,6 +106,7 @@ export const SmartSongListCard = memo(function SongListCards({
 										<SongVariantCard
 											data={v}
 											key={v.packGuid}
+											dense={props.dense}
 											properties={['SHOW_PRIVATE_LABEL']}
 										/>
 									))
@@ -116,6 +119,7 @@ export const SmartSongListCard = memo(function SongListCards({
 										<SongVariantCard
 											data={v}
 											key={v.packGuid}
+											dense={props.dense}
 											properties={['SHOW_PRIVATE_LABEL']}
 										/>
 									)),
@@ -140,6 +144,7 @@ export const SmartSongListCard = memo(function SongListCards({
 							<SongVariantCard
 								data={v}
 								key={v.packGuid}
+								dense={props.dense}
 								properties={['SHOW_PRIVATE_LABEL']}
 							/>
 						))
@@ -152,6 +157,7 @@ export const SmartSongListCard = memo(function SongListCards({
 							<SongVariantCard
 								data={v}
 								key={v.packGuid}
+								dense={props.dense}
 								properties={['SHOW_PRIVATE_LABEL']}
 							/>
 						)),

--- a/src/common/components/songLists/SongListCards/SongListCards.tsx
+++ b/src/common/components/songLists/SongListCards/SongListCards.tsx
@@ -10,6 +10,7 @@ type CommmonProps = {
 	data: BasicVariantPack[]
 	properties?: ComponentProps<typeof SongVariantCard>['properties']
 	cardToLinkProps?: ComponentProps<typeof SongVariantCard>['toLinkProps']
+	dense?: boolean
 	onCardClick?: (data: BasicVariantPack) => void
 
 	// Selecting
@@ -77,6 +78,7 @@ export const SongListCard = memo(function SongListCards({
 					data={v}
 					key={v.packGuid}
 					flexibleHeight={flexibleHeight}
+					dense={props.dense}
 					toLinkProps={props.cardToLinkProps}
 					properties={props.properties}
 					onClick={() => {

--- a/src/common/ui/SongCard/SongCard.story.tsx
+++ b/src/common/ui/SongCard/SongCard.story.tsx
@@ -15,7 +15,12 @@ const SongCardStory = () => {
 		public: false,
 	} as BasicVariantPack
 
-	return <SongVariantCard data={data} />
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+			<SongVariantCard data={data} />
+			<SongVariantCard data={data} dense />
+		</div>
+	)
 }
 
 createStory(SongVariantCard, SongCardStory)

--- a/src/common/ui/SongCard/SongGroupCard.tsx
+++ b/src/common/ui/SongCard/SongGroupCard.tsx
@@ -13,11 +13,13 @@ type SongGroupCardProps = {
 	packs: BasicVariantPack[]
 	original?: BasicVariantPack
 	flexibleHeight?: boolean
+	dense?: boolean
 	toLinkProps?: ToLinkProps
 }
 
 export default function SongGroupCard({
 	flexibleHeight = true,
+	dense = false,
 	packs,
 	original,
 	...props
@@ -82,7 +84,11 @@ export default function SongGroupCard({
 									transition: 'bottom 0.2s, transform 0.2s',
 								}}
 							>
-								<SongVariantCard data={d} flexibleHeight={flexibleHeight} />
+								<SongVariantCard
+									data={d}
+									flexibleHeight={flexibleHeight}
+									dense={dense}
+								/>
 							</Box>
 						)
 					})}
@@ -91,6 +97,7 @@ export default function SongGroupCard({
 				<SongVariantCard
 					data={first}
 					flexibleHeight={flexibleHeight}
+					dense={dense}
 					sx={{
 						...(original
 							? {

--- a/src/common/ui/SongCard/SongVariantCard.tsx
+++ b/src/common/ui/SongCard/SongVariantCard.tsx
@@ -62,6 +62,8 @@ type SongCardIconData = (
 type SongCardProps = {
 	data: BasicVariantPack
 	flexibleHeight?: boolean
+	/** Compact list-row look: single preview line, tighter padding (mobile lists) */
+	dense?: boolean
 	properties?: SongCardProperty[]
 	toLinkProps?: ToLinkProps
 	selected?: boolean
@@ -75,6 +77,7 @@ type SongCardProps = {
 export const SongVariantCard = memo(function S({
 	data,
 	flexibleHeight: flexibleHeght = true,
+	dense = false,
 	...props
 }: SongCardProps) {
 	const t = useTranslations('common')
@@ -111,7 +114,10 @@ export const SongVariantCard = memo(function S({
 	// Title and sheet data to display
 	const title = data.title
 	const sheet = new Sheet(data.sheetData)
-	const dataLines = sheet.getSections()[0]?.text?.split('\n').slice(0, 4)
+	const dataLines = sheet
+		.getSections()[0]
+		?.text?.split('\n')
+		.slice(0, dense ? 1 : 4)
 
 	const linkProps = useMemo(() => {
 		if (props.toLinkProps) {
@@ -238,7 +244,7 @@ export const SongVariantCard = memo(function S({
 					sx={{
 						outlineColor: showPrivate ? theme.palette.grey[300] : 'transparent',
 
-						height: flexibleHeght ? 'auto' : '11rem',
+						height: flexibleHeght || dense ? 'auto' : '11rem',
 						overflowY: 'hidden',
 
 						...(selected && {
@@ -256,7 +262,7 @@ export const SongVariantCard = memo(function S({
 					<Box
 						sx={{
 							position: 'relative',
-							padding: '1rem',
+							padding: dense ? '0.6rem 1rem' : '1rem',
 							...(selected && {
 								borderColor: 'primary.main',
 								borderWidth: 2,
@@ -266,7 +272,7 @@ export const SongVariantCard = memo(function S({
 									bgcolor: alpha(theme.palette.primary.main, 0.2),
 								},
 							}),
-							height: 'calc(100% - 2rem)',
+							height: dense ? 'auto' : 'calc(100% - 2rem)',
 							display: 'flex',
 							flexDirection: 'column',
 							overflow: 'hidden',
@@ -275,6 +281,7 @@ export const SongVariantCard = memo(function S({
 						<Box display={'flex'} flexDirection={'row'} gap={1}>
 							<Typography
 								strong
+								noWrap={dense}
 								sx={{
 									flex: 1,
 									...(!data.ggValidated &&
@@ -341,6 +348,8 @@ export const SongVariantCard = memo(function S({
 										>
 											<Typography
 												key={'SearchItemText' + index}
+												small={dense}
+												noWrap={dense}
 												sx={{
 													flex: 1,
 												}}

--- a/src/common/ui/SongCard/SongVariantCard.tsx
+++ b/src/common/ui/SongCard/SongVariantCard.tsx
@@ -64,6 +64,8 @@ type SongCardProps = {
 	flexibleHeight?: boolean
 	/** Compact list-row look: single preview line, tighter padding (mobile lists) */
 	dense?: boolean
+	/** Override how many lyric preview lines to show (defaults: dense=1, else 4) */
+	previewLines?: number
 	properties?: SongCardProperty[]
 	toLinkProps?: ToLinkProps
 	selected?: boolean
@@ -114,10 +116,11 @@ export const SongVariantCard = memo(function S({
 	// Title and sheet data to display
 	const title = data.title
 	const sheet = new Sheet(data.sheetData)
+	const previewLineCount = props.previewLines ?? (dense ? 1 : 4)
 	const dataLines = sheet
 		.getSections()[0]
 		?.text?.split('\n')
-		.slice(0, dense ? 1 : 4)
+		.slice(0, previewLineCount)
 
 	const linkProps = useMemo(() => {
 		if (props.toLinkProps) {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -28,6 +28,7 @@ export const routesPaths = {
 	songsList: '/seznam',
 	test: '/test',
 	testComponents: '/storybook',
+	demoMobile: '/demo-mobil',
 	subdomain: '/sub/[subdomain]',
 	about: '/o-nas',
 	contact: '/kontakt',
@@ -93,5 +94,8 @@ export const routesSearchParams = {
 	},
 	songsList: {
 		s: 0 as number | undefined,
+	},
+	demoMobile: {
+		v: 0 as number | undefined,
 	},
 }


### PR DESCRIPTION
Superseded by #517 (same changes on a shorter branch name `claude/mobile-home`, to get a shorter preview-deploy subdomain). Closing in favor of #517.