### PR TITLE
Fix unhandled fullscreen API errors in song presentation mode

### DIFF
--- a/src/common/components/PresentationLayout/PresentationLayout.tsx
+++ b/src/common/components/PresentationLayout/PresentationLayout.tsx
@@ -95,13 +95,23 @@ export default function PresentationLayout({
 	}
 
 	const turnOnFullscreen = () => {
-		document.body.requestFullscreen()
-		setFullscreen(true)
+		if (!document.body.requestFullscreen || document.fullscreenElement) {
+			return
+		}
+		document.body.requestFullscreen().catch(() => {
+			// Fullscreen can be rejected by the browser (unsupported, no user
+			// activation, permissions policy, ...) - ignore, state stays in sync
+			// via the fullscreenchange listener below.
+		})
 	}
 
 	const turnOffFullscreen = () => {
-		document.exitFullscreen()
-		setFullscreen(false)
+		if (!document.exitFullscreen || !document.fullscreenElement) {
+			return
+		}
+		document.exitFullscreen().catch(() => {
+			// See turnOnFullscreen - ignore rejections, fullscreenchange syncs state.
+		})
 	}
 
 	useEffect(() => {
@@ -110,6 +120,16 @@ export default function PresentationLayout({
 			document.removeEventListener('keydown', onKeyDown)
 		}
 	}, [items])
+
+	useEffect(() => {
+		const onFullscreenChange = () => {
+			setFullscreen(!!document.fullscreenElement)
+		}
+		document.addEventListener('fullscreenchange', onFullscreenChange)
+		return () => {
+			document.removeEventListener('fullscreenchange', onFullscreenChange)
+		}
+	}, [])
 
 	return (
 		<Box overflow={'hidden'}>


### PR DESCRIPTION
## Summary

Fixes the most frequent production error group from the past week's Sentry logs: unguarded Fullscreen API calls in the song presentation mode (`/pisen/*/prezentace`).

`PresentationLayout` called `document.body.requestFullscreen()` / `document.exitFullscreen()` directly from swipe-up/swipe-down gesture handlers with no feature detection, no promise-rejection handling, and no sync between the local `fullscreen` boolean and the browser's actual fullscreen state. This crashed on:
- iOS Safari, where body-level `requestFullscreen` doesn't exist at all (`TypeError: ... is not a function`)
- Any browser where the user/browser had already left fullscreen outside the swipe-down handler (`TypeError: Not in fullscreen`)
- Chrome, when the fullscreen request promise rejects because the call isn't tied to sufficiently direct user activation (`TypeError: Permissions check failed`)

## Changes

- `turnOnFullscreen`/`turnOffFullscreen` now feature-detect the API and check `document.fullscreenElement` before calling, and `.catch()` the returned promise instead of leaving it unhandled.
- Added a `fullscreenchange` listener that syncs the `fullscreen` state to the browser's real state, so a manual exit (Esc, OS back gesture, etc.) doesn't leave the component's state out of sync with reality.

## Test plan

- [x] `npm run check-types` — no new errors (pre-existing unrelated `.svg`/module errors confirmed present on `dev` too)
- [x] `npm run lint` — clean (pre-existing unrelated warning in `SheetPDF.tsx`)
- [x] `npx jest PresentationLayout` — 23/23 passing
- [ ] Manual check on the preview deploy: open a song presentation page on iOS Safari, swipe up/down, confirm no console errors and fullscreen toggles correctly

Fixes #520

Sentry issues resolved: [WT-FRONTEND-1](https://petr-pavlin.sentry.io/issues/WT-FRONTEND-1), [WT-FRONTEND-2](https://petr-pavlin.sentry.io/issues/WT-FRONTEND-2), [WT-FRONTEND-4](https://petr-pavlin.sentry.io/issues/WT-FRONTEND-4), [WT-FRONTEND-6](https://petr-pavlin.sentry.io/issues/WT-FRONTEND-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnZxH5xX5EEnXB79hUi6PH


---
_Generated by [Claude Code](https://claude.ai/code/session_01KnZxH5xX5EEnXB79hUi6PH)_