### PR TITLE
Stop reporting expected 403s to Sentry from the page error boundary

### DIFF
--- a/src/app/(layout)/sub/admin/layout.tsx
+++ b/src/app/(layout)/sub/admin/layout.tsx
@@ -4,13 +4,32 @@ import AdminMenu from '@/app/(layout)/sub/admin/components/AdminMenu'
 import { checkFlag } from '@/common/providers/FeatureFlags/flags.tech'
 import { LayoutProps } from '@/common/types'
 import { Box } from '@/common/ui'
+import { useServerPathname } from '@/hooks/pathname/useServerPathname'
+import { ROLES } from '@/interfaces/user'
 import { getServerUser } from '@/tech/auth/getServerUser'
 import { forbidden } from '@/tech/error/error.tech'
+import * as Sentry from '@sentry/nextjs'
 
 export default async function Layout(props: LayoutProps<'admin'>) {
 	const user = getServerUser()
 	const show = await checkFlag('show_admin_page', user)
-	if (!show) forbidden()
+	if (!show) {
+		// Not a bug - the show_admin_page gate is the access control itself,
+		// working as intended. Reported as a warning (not an exception) so it's
+		// visible in Sentry without counting toward the error rate; error.tsx
+		// skips re-reporting this same denial as an exception.
+		const pathname = await useServerPathname()
+		Sentry.captureMessage('Forbidden admin access attempt', {
+			level: 'warning',
+			tags: { area: 'admin', authenticated: String(!!user) },
+			extra: {
+				pathname,
+				userGuid: user?.guid,
+				role: user ? ROLES[user.role] : undefined,
+			},
+		})
+		forbidden()
+	}
 	// throw forbidden exception with status code 403
 
 	return (

--- a/src/app/(layout)/sub/admin/layout.tsx
+++ b/src/app/(layout)/sub/admin/layout.tsx
@@ -4,32 +4,13 @@ import AdminMenu from '@/app/(layout)/sub/admin/components/AdminMenu'
 import { checkFlag } from '@/common/providers/FeatureFlags/flags.tech'
 import { LayoutProps } from '@/common/types'
 import { Box } from '@/common/ui'
-import { useServerPathname } from '@/hooks/pathname/useServerPathname'
-import { ROLES } from '@/interfaces/user'
 import { getServerUser } from '@/tech/auth/getServerUser'
 import { forbidden } from '@/tech/error/error.tech'
-import * as Sentry from '@sentry/nextjs'
 
 export default async function Layout(props: LayoutProps<'admin'>) {
 	const user = getServerUser()
 	const show = await checkFlag('show_admin_page', user)
-	if (!show) {
-		// Not a bug - the show_admin_page gate is the access control itself,
-		// working as intended. Reported as a warning (not an exception) so it's
-		// visible in Sentry without counting toward the error rate; error.tsx
-		// skips re-reporting this same denial as an exception.
-		const pathname = await useServerPathname()
-		Sentry.captureMessage('Forbidden admin access attempt', {
-			level: 'warning',
-			tags: { area: 'admin', authenticated: String(!!user) },
-			extra: {
-				pathname,
-				userGuid: user?.guid,
-				role: user ? ROLES[user.role] : undefined,
-			},
-		})
-		forbidden()
-	}
+	if (!show) forbidden()
 	// throw forbidden exception with status code 403
 
 	return (

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -18,10 +18,10 @@ export default function Error({ error, reset, skipReport }: ErrorPageProps) {
 
 	useEffect(() => {
 		console.error('Error page error:', error)
-		if (!skipReport) {
+		if (!skipReport && errorType !== 'forbidden') {
 			Sentry.captureException(error, { tags: { errorBoundary: 'page' } })
 		}
-	}, [error, skipReport])
+	}, [error, errorType, skipReport])
 
 	return (
 		<Box

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,6 +2,8 @@
 
 import { ErrorPageProps } from '@/common/types'
 import { Box, Button, Typography } from '@/common/ui'
+import useAuth from '@/hooks/auth/useAuth'
+import { useClientPathname } from '@/hooks/pathname/useClientPathname'
 import { LockPerson } from '@mui/icons-material'
 import * as Sentry from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
@@ -12,16 +14,29 @@ type ErrorType = 'forbidden' | 'default'
 export default function Error({ error, reset, skipReport }: ErrorPageProps) {
 	const t = useTranslations('errors')
 	const tCommon = useTranslations('common')
+	const pathname = useClientPathname()
+	const { user } = useAuth()
 	const errorType: ErrorType = useMemo(() => {
 		return error.message.includes('Forbidden') ? 'forbidden' : 'default'
 	}, [error])
 
 	useEffect(() => {
 		console.error('Error page error:', error)
-		if (!skipReport && errorType !== 'forbidden') {
+		if (skipReport) return
+
+		if (errorType === 'forbidden') {
+			// Being denied access is the access control working as intended, not
+			// a bug - keep it visible in Sentry as a warning (not an exception)
+			// so it doesn't count toward the error rate.
+			Sentry.captureMessage(error.message, {
+				level: 'warning',
+				tags: { errorBoundary: 'page', authenticated: String(!!user) },
+				extra: { pathname, userGuid: user?.guid, role: user?.role },
+			})
+		} else {
 			Sentry.captureException(error, { tags: { errorBoundary: 'page' } })
 		}
-	}, [error, errorType, skipReport])
+	}, [error, errorType, skipReport, pathname, user])
 
 	return (
 		<Box


### PR DESCRIPTION
## Summary

Fixes the most frequent unresolved error group from the past week's Sentry logs: `admin.chvalotce.cz` throws an expected `Forbidden` error for every anonymous/non-admin visitor (the admin layout gates access via a feature flag), and `src/app/error.tsx` already renders the correct "access denied" UI for it — but the reporting effect ran unconditionally and sent every occurrence to Sentry as a full application error (`captureException`) regardless.

This isn't a security gap: `if (!show) forbidden()` in the admin layout *is* the access-control check itself — nobody gets past it, they just see the "access denied" screen. The problem was purely how it got reported to Sentry.

## Changes

- `src/app/error.tsx`: for `errorType === 'forbidden'`, report a `Sentry.captureMessage(..., { level: 'warning' })` instead of `captureException` — so denied-access attempts stay visible and searchable in Sentry (with pathname + user context pulled from `useClientPathname()`/`useAuth()`), without counting toward the error rate/alerting like a real crash. Non-forbidden errors are unaffected.
- This lives in the single shared error boundary rather than at the one admin call site, so it automatically covers any future `forbidden()` caller too, not just this one.

## Test plan

- [x] `npm run check-types` — no new errors (pre-existing unrelated `.svg` module errors confirmed present on `dev` too)
- [x] `npx eslint` on both changed files — clean
- [x] `npm run test:jest` — 506/506 passing

Fixes #522

Sentry issue resolved: [WT-FRONTEND-A](https://petr-pavlin.sentry.io/issues/WT-FRONTEND-A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARTVu2bpg4A5R3dLDqnADG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARTVu2bpg4A5R3dLDqnADG)_