### PR TITLE
Fix team playlist page crash when the view-tick request fails

### DIFF
--- a/src/app/(submodules)/(teams)/sub/tymy/(teampage)/[alias]/playlist/[guid]/layout.tsx
+++ b/src/app/(submodules)/(teams)/sub/tymy/(teampage)/[alias]/playlist/[guid]/layout.tsx
@@ -30,8 +30,12 @@ export const generateMetadata = generateSmartMetadata(
 export default async function Layout(props: LayoutProps<'teamPlaylist'>) {
 	const { playlistGettingApi } = await useServerApi()
 
-	// Send tick to backend
-	await playlistGettingApi.updatePlaylistOpenDate(props.params.guid)
+	try {
+		// Send tick to backend
+		await playlistGettingApi.updatePlaylistOpenDate(props.params.guid)
+	} catch (e) {
+		console.log('Please log-in')
+	}
 
 	return (
 		<TeamPlaylistClientProviders>{props.children}</TeamPlaylistClientProviders>


### PR DESCRIPTION
## Summary

Fixes the highest-frequency *new* error group from the past week's Sentry logs (excluding the fullscreen-crash and admin-403 groups already covered by #520/#521 and #522/#523): the team playlist layout awaits a non-critical "mark playlist as opened" backend call with no error handling, so a 401 from that call crashes the whole page instead of just skipping the tick.

## Changes

- `src/app/(submodules)/(teams)/sub/tymy/(teampage)/[alias]/playlist/[guid]/layout.tsx`: wrap the `updatePlaylistOpenDate` call in `try/catch`, matching the existing pattern already used by the personal (non-team) playlist layout at `src/app/(layout)/playlist/[guid]/layout.tsx`.

## Test plan

- [x] `npm run check-types` — no new errors (pre-existing unrelated `.svg` module errors confirmed present on `dev` too)
- [x] `npx eslint` on the changed file — clean
- [x] `npm run test:jest` — 506/506 passing

Fixes #524

Sentry issue resolved: [WT-FRONTEND-C](https://petr-pavlin.sentry.io/issues/WT-FRONTEND-C)

🤖 Generated with [Claude Code](https://claude.ai/code/session_01PCsgbyC4gHJeghcQvWaxRo)

https://claude.ai/code/session_01PCsgbyC4gHJeghcQvWaxRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCsgbyC4gHJeghcQvWaxRo)_