### PR TITLE
Fix leaked swipe listeners crashing on stray touch events on unrelated pages

### DIFF
--- a/src/common/components/PresentationLayout/PresentationLayout.tsx
+++ b/src/common/components/PresentationLayout/PresentationLayout.tsx
@@ -43,26 +43,43 @@ export default function PresentationLayout({
 	useEffect(() => {
 		if (items.length === 0) return
 
-		// Swipe events
-		const { swipeArea } = SwipeEventListener({
-			swipeArea: document.querySelector('body') as HTMLElement,
-		})
+		const swipeArea = document.querySelector('body') as HTMLElement
 
-		const remove = () => {
-			swipeArea.removeEventListener('swipeRight', right)
-			swipeArea.removeEventListener('swipeLeft', left)
-			swipeArea.removeEventListener('swipeUp', up)
-			swipeArea.removeEventListener('swipeDown', down)
-		}
+		// swipe-event-listener attaches its own raw touch/mouse listeners to
+		// swipeArea and exposes no way to tear them down. Since swipeArea is
+		// <body>, which Next.js keeps mounted across client-side navigation,
+		// those listeners would otherwise leak onto every other page for the
+		// rest of the session. Intercept addEventListener while the library
+		// wires itself up so every listener it (and we) register here can be
+		// removed again on cleanup.
+		const registered: {
+			type: string
+			listener: EventListenerOrEventListenerObject
+		}[] = []
+		const originalAddEventListener = swipeArea.addEventListener.bind(swipeArea)
+		swipeArea.addEventListener = ((
+			type: string,
+			listener: EventListenerOrEventListenerObject,
+			options?: boolean | AddEventListenerOptions,
+		) => {
+			registered.push({ type, listener })
+			originalAddEventListener(type, listener, options)
+		}) as typeof swipeArea.addEventListener
 
-		remove()
+		SwipeEventListener({ swipeArea })
 
 		swipeArea.addEventListener('swipeRight', right)
 		swipeArea.addEventListener('swipeLeft', left)
 		swipeArea.addEventListener('swipeUp', up)
 		swipeArea.addEventListener('swipeDown', down)
 
-		return remove
+		swipeArea.addEventListener = originalAddEventListener
+
+		return () => {
+			registered.forEach(({ type, listener }) =>
+				swipeArea.removeEventListener(type, listener),
+			)
+		}
 	}, [items])
 
 	const moveCurrent = (offset: number) => {


### PR DESCRIPTION
## Summary

Fixes the second-most-frequent *new* unresolved error group from this week's Sentry sweep (excluding the fullscreen-crash and admin-403/team-401 groups already covered by prior issues/PRs): `PresentationLayout` attaches `swipe-event-listener`'s raw `touchstart`/`touchmove`/`touchend`/`mousedown`/`mousemove`/`mouseup` listeners to `document.body` but never removes them. Since `<body>` persists across Next.js App Router client-side navigation, those listeners leak onto every other page for the rest of the session (and duplicate further on every presentation-page visit), and the library's internal `touchmove` handler indexes into `event.touches[0]` with no guard — so any caller that invokes the leaked listener with a non-standard event (observed: Seznam prohlížeč's injected `szn-arrow` gesture UI on Android) throws an unhandled `TypeError`, even on pages that never render presentation mode at all (e.g. `/kontakt`).

## Changes

- `src/common/components/PresentationLayout/PresentationLayout.tsx`: temporarily wrap `swipeArea.addEventListener` while `SwipeEventListener()` wires itself up (and while we add our own custom `swipeUp`/`swipeDown`/`swipeLeft`/`swipeRight` listeners), recording every `(type, listener)` pair registered. The effect's cleanup now removes all of them, not just the 4 custom listeners it added directly — so nothing survives past unmount/re-run.

## Test plan

- [x] `npm run check-types` — no new errors introduced (pre-existing unrelated e2e/Playwright module-resolution errors confirmed present before this change too)
- [x] `npx eslint src/common/components/PresentationLayout/PresentationLayout.tsx` — clean
- [x] `npm run test:jest` — 506/506 passing

Fixes #526

Sentry issue resolved: [WT-FRONTEND-8](https://petr-pavlin.sentry.io/issues/WT-FRONTEND-8)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0177jBhaZ8rsQzp6GDf8GZri)_